### PR TITLE
Changing default ATM_NCPL for ARRM60to10 B-cases

### DIFF
--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -376,7 +376,7 @@
       <value compset="_EAM.*_ELM.*MPASO">48</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne11np4">12</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne120np4">96</value>
-      <value compset="_EAM.*_ELM.*MPASO" grid="oi%oARRM60to10">96</value>
+      <value compset="_EAM.*_ELM.*MPASO" grid="oi%oARRM60to10">48</value>
       <value compset=".+" grid="a%0.23x0.31">96</value>
       <value compset=".+" grid="a%ne4np4">12</value>
       <value compset=".+" grid="a%ne4np4.pg2">24</value>
@@ -432,7 +432,7 @@
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne4np4">$ATM_NCPL</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne11np4">12</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne120np4">96</value>
-      <value compset="_EAM.*_ELM.*MPASO" grid="oi%oARRM60to10">96</value>
+      <value compset="_EAM.*_ELM.*MPASO" grid="oi%oARRM60to10">48</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
This changes the default ATM_NCPL (and LND_NCPL) from 96 to 48, needed for the ARRM60to10 B-cases.

Note the location of this change has changed since the previous E3SM-Arctic branch.