### PR TITLE
Update seaice IC for v2

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -239,12 +239,12 @@ def buildnml(case, caseroot, compname):
         decomp_date = '180723'
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.monthlyClimatology.PHC2_salx.2004_08_03.ARRM60to10.190129.nc'
-        analysis_mask_file = 'ARRM60to10_SingleRegionAtlanticWTransportTransects_masks.nc'
+        analysis_mask_file = 'ARRM60to10_mocBasinsAndTransects20210623.nc'
         ic_date = '180715'
         ic_prefix = 'ocean.ARRM60to10'
         if ocn_ic_mode == 'spunup':
-            ic_date = '200422'
-            ic_prefix = 'ocean.ARRM60to10.restart_grizzly'
+            ic_date = '210204'
+            ic_prefix = 'mpaso.oARRM60to10.rstFromG-cori'
 
     elif ocn_grid == 'oARRM60to6':
         decomp_date = '180820'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -249,8 +249,8 @@ def buildnml(case, caseroot, compname):
         grid_date = '180715'
         grid_prefix = 'seaice.ARRM60to10'
         if ice_ic_mode == 'spunup':
-            grid_date = '200422'
-            grid_prefix = 'seaice.ARRM60to10.restart_grizzly'
+            grid_date = '210204'
+            grid_prefix = 'mpassi.oARRM60to10.rstFromG-cori'
 
     elif ice_grid == 'oARRM60to6':
         decomp_date = '180820'


### PR DESCRIPTION
Bringing over this fix from e3sm:

Updates the ocean and sea ice initial conditions for spun-up compsets using the ARRM60to10 grid. This is needed to replace the existing sea ice initial condition, which has one snow layer, and is not compatible with v2. These new ocean and sea ice initial conditions are generated from restarts from a one month G-case using cold start initial conditions.

This also updates the ocean analysis mask file to include additional regions in addition to just Atlantic, which was the only one in the previous file it is replacing.