### PR TITLE
Add testmods for E3SMv2-Arctic configuration

### DIFF
--- a/cime_config/testmods_dirs/allactive/v2arctic/shell_commands
+++ b/cime_config/testmods_dirs/allactive/v2arctic/shell_commands
@@ -1,0 +1,3 @@
+#!/bin/bash
+./xmlchange --append CAM_CONFIG_OPTS='-cosp'
+

--- a/cime_config/testmods_dirs/allactive/v2arctic/shell_commands
+++ b/cime_config/testmods_dirs/allactive/v2arctic/shell_commands
@@ -1,3 +1,3 @@
 #!/bin/bash
 ./xmlchange --append CAM_CONFIG_OPTS='-cosp'
-
+export DIN_LOC_ROOT=/global/cfs/cdirs/e3sm/inputdata

--- a/cime_config/testmods_dirs/allactive/v2arctic/user_nl_eam
+++ b/cime_config/testmods_dirs/allactive/v2arctic/user_nl_eam
@@ -1,0 +1,19 @@
+! Users should add all user specific namelist changes below in the form of 
+! namelist_var = new_namelist_value 
+ 
+ nhtfrq =   0,-24,-6,-6,-3,-24,0
+ mfilt  = 1,30,120,120,240,30,1
+ avgflag_pertape = 'A','A','I','A','A','A','I'
+ fexcl1 = 'CFAD_SR532_CAL', 'LINOZ_DO3', 'LINOZ_DO3_PSC', 'LINOZ_O3CLIM', 'LINOZ_O3COL', 'LINOZ_SSO3', 'hstobie_linoz'
+ fincl1 = 'extinct_sw_inp','extinct_lw_bnd7','extinct_lw_inp','CLD_CAL', 'TREFMNAV', 'TREFMXAV'
+ fincl2 = 'FLUT','PRECT','U200','V200','U850','V850','Z500','OMEGA500','UBOT','VBOT','TREFHT','TREFHTMN:M','TREFHTMX:X','QREFHT','TS','PS','TMQ','TUQ','TVQ','TOZ', 'FLDS', 'FLNS', 'FSDS', 'FSNS', 'SHFLX', 'LHFLX', 'TGCLDCWP', 'TGCLDIWP', 'TGCLDLWP', 'CLDTOT', 'T250', 'T200', 'T150', 'T100', 'T050', 'T025', 'T010', 'T005', 'T002', 'T001', 'TTOP', 'U250', 'U150', 'U100', 'U050', 'U025', 'U010', 'U005', 'U002', 'U001', 'UTOP', 'FSNT', 'FLNT'
+ fincl3 = 'PSL','T200','T500','U850','V850','UBOT','VBOT','TREFHT', 'Z700', 'TBOT:M'
+ fincl4 = 'FLUT','U200','U850','PRECT','OMEGA500'
+ fincl5 = 'PRECT','PRECC','TUQ','TVQ','QFLX','SHFLX','U90M','V90M'
+ fincl6 = 'CLDTOT_ISCCP','MEANCLDALB_ISCCP','MEANTAU_ISCCP','MEANPTOP_ISCCP','MEANTB_ISCCP','CLDTOT_CAL','CLDTOT_CAL_LIQ','CLDTOT_CAL_ICE','CLDTOT_CAL_UN','CLDHGH_CAL','CLDHGH_CAL_LIQ','CLDHGH_CAL_ICE','CLDHGH_CAL_UN','CLDMED_CAL','CLDMED_CAL_LIQ','CLDMED_CAL_ICE','CLDMED_CAL_UN','CLDLOW_CAL','CLDLOW_CAL_LIQ','CLDLOW_CAL_ICE','CLDLOW_CAL_UN'
+ fincl7 = 'O3', 'PS', 'TROP_P'
+
+! Additional retuning
+ clubb_tk1 = 268.15D0
+ gw_convect_hcf = 10.0
+ history_aerosol = .true.

--- a/cime_config/testmods_dirs/allactive/v2arctic/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/v2arctic/user_nl_elm
@@ -1,0 +1,32 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes below in the form of 
+! namelist_var = new_namelist_value 
+!
+! Include namelist variables for drv_flds_in ONLY if -megan and/or -drydep options
+! are set in the CLM_NAMELIST_OPTS env variable.
+!
+! EXCEPTIONS: 
+! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting
+! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting
+! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting
+! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting
+! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting
+! Set irrigate           by the CLM_BLDNML_OPTS -irrig           setting
+! Set co2_ppmv           with CCSM_CO2_PPMV                      option
+! Set dtime              with L_NCPL                             option
+! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options
+! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases
+!                        (includes $inst_string for multi-ensemble cases)
+! Set glc_grid           with CISM_GRID                          option
+! Set glc_smb            with GLC_SMB                            option
+! Set maxpatch_glcmec    with GLC_NEC                            option
+! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable
+!----------------------------------------------------------------------------------
+
+ hist_dov2xy = .true.,.true.
+ hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
+ hist_mfilt = 1,365
+ hist_nhtfrq = 0,-24
+ hist_avgflag_pertape = 'A','A'
+ fsurdat = '/global/cfs/cdirs/e3sm/inputdata/lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1950_c210729.nc'
+ finidat = '/global/cfs/cdirs/e3sm/inputdata/lnd/clm2/initdata/20210817.ICRUELM-1950.ne30pg2_oARRM60to10.elm.r.0051-01-01-00000.nc'

--- a/cime_config/testmods_dirs/allactive/v2arctic/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/v2arctic/user_nl_elm
@@ -28,5 +28,5 @@
  hist_mfilt = 1,365
  hist_nhtfrq = 0,-24
  hist_avgflag_pertape = 'A','A'
- fsurdat = '/global/cfs/cdirs/e3sm/inputdata/lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1950_c210729.nc'
- finidat = '/global/cfs/cdirs/e3sm/inputdata/lnd/clm2/initdata/20210817.ICRUELM-1950.ne30pg2_oARRM60to10.elm.r.0051-01-01-00000.nc'
+ fsurdat = '${DIN_LOC_ROOT}/lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1950_c210729.nc'
+ finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata/20210817.ICRUELM-1950.ne30pg2_oARRM60to10.elm.r.0051-01-01-00000.nc'

--- a/cime_config/testmods_dirs/allactive/v2arctic/user_nl_mosart
+++ b/cime_config/testmods_dirs/allactive/v2arctic/user_nl_mosart
@@ -1,0 +1,15 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes below in the form of 
+! namelist_var = new_namelist_value 
+! NOTE: namelist variable coupling_period CAN ONLY be changed by modifying the value
+!       of the xml variable ROF_NCPL in env_run.xml
+! NOTE: if the xml variable ROF GRID in env_build.xml is set to 'null', then
+!        the RTM build-namelist will set do_rtm to .false. - and will ignore 
+!        any change below
+!----------------------------------------------------------------------------------
+
+
+ rtmhist_fincl2 = 'RIVER_DISCHARGE_OVER_LAND_LIQ'
+ rtmhist_mfilt = 1,365
+ rtmhist_ndens = 2
+ rtmhist_nhtfrq = 0,-24

--- a/cime_config/testmods_dirs/allactive/v2arctic/user_nl_mpaso
+++ b/cime_config/testmods_dirs/allactive/v2arctic/user_nl_mpaso
@@ -1,0 +1,47 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes after these comments 
+! in the form of 
+!   namelist_var = new_namelist_value 
+! *** EXCEPT FOR ***
+! 1. DO NOT CHANGE config_start_time, config_run_duration, config_stop_time,
+!    config_do_restart, config_Restart_timestamp_filename, config_calendar_type, 
+!    config_set_restingThickness_to_IC, config_alter_ICs_for_pbcs 
+! 2. To preview the namelists, invoke $CASEROOT preview-namelists and look at 
+!    $CASEROOT/CaseDocs/mpaso_in
+!
+!
+! Users cannot use this file to configure streams. In order to configure streams, 
+! write a stream configuration file, and place it in 
+! SourceMods/src.mpaso/streams.ocean
+!----------------------------------------------------------------------------------
+
+!----------------------------------------------------------------------------------
+! changes to defaults
+!----------------------------------------------------------------------------------
+ config_gm_spatially_variable_max_kappa = 3000.0
+ config_gm_spatially_variable_min_kappa = 600.0
+ config_cvmix_background_scheme = 'bryanlewis'
+! config_cvmix_bryanlewis_bl1 = 0.3E-4
+ config_cvmix_bryanlewis_bl1 = 0.8E-4
+ config_cvmix_bryanlewis_bl2 = 1.3E-4
+ config_cvmix_bryanlewis_transitiondepth = 1000.0
+ config_cvmix_bryanlewis_transitionwidth = 250.0
+ config_use_mom_del2 = .true.
+! config_tracer_del2 = 100.0
+! config_mom_del2 = 1000.0
+! config_mom_del4 = 1.2e11
+ config_am_mocstreamfunction_enable = .true.
+
+!----------------------------------------------------------------------------------
+! defaults, but may want to change
+!----------------------------------------------------------------------------------
+! config_gm_closure = 'EdenGreatbatch'
+! config_redi_closure = 'constant'
+! config_redi_constant_kappa = 400.0
+! config_cvmix_prandtl_number = 1.0
+! config_use_cvmix_tidal_mixing = .false.
+
+!----------------------------------------------------------------------------------
+! For G-cases only
+!----------------------------------------------------------------------------------
+! config_salinity_restoring_constant_piston_velocity = 1.9013e-5

--- a/cime_config/testmods_dirs/allactive/v2arctic/user_nl_mpassi
+++ b/cime_config/testmods_dirs/allactive/v2arctic/user_nl_mpassi
@@ -1,0 +1,19 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes after these comments 
+! in the form of 
+!   namelist_var = new_namelist_value 
+! *** EXCEPT FOR ***
+! 1. DO NOT CHANGE config_start_time, config_run_duration, config_stop_time,
+!    config_do_restart, config_Restart_timestamp_filename, config_calendar_type, 
+!    config_set_restingThickness_to_IC, config_alter_ICs_for_pbcs 
+! 2. To preview the namelists, invoke $CASEROOT preview-namelists and look at 
+!    $CASEROOT/CaseDocs/mpassi_in
+!
+!
+! Users cannot use this file to configure streams. In order to configure streams, 
+! write a stream configuration file, and place it in 
+! SourceMods/src.mpassi/streams.seaice
+!----------------------------------------------------------------------------------
+
+! config_block_decomp_file_prefix = '/global/cfs/cdirs/e3sm/inputdata/ice/mpas-cice/oARRM60to10/mpas-seaice.graph.v2.190129.part.'
+! config_nSnowLayers = 1

--- a/cime_config/testmods_dirs/allactive/v2arctic/user_nl_mpassi
+++ b/cime_config/testmods_dirs/allactive/v2arctic/user_nl_mpassi
@@ -15,5 +15,4 @@
 ! SourceMods/src.mpassi/streams.seaice
 !----------------------------------------------------------------------------------
 
-! config_block_decomp_file_prefix = '/global/cfs/cdirs/e3sm/inputdata/ice/mpas-cice/oARRM60to10/mpas-seaice.graph.v2.190129.part.'
-! config_nSnowLayers = 1
+! config_ratio_ridging_work_to_PE = 34.0


### PR DESCRIPTION
This adds testmods for the E3SMv2-Arctic configuration currently being run, including changes to namelist defaults.

This can be used by the following, on Cori-KNL as an example:

```
cd cime/scripts
./create_test ERS.ne30pg2_oARRM60to10.WCYCL1850.cori-knl_intel.allactive-v2arctic --project m1199 --walltime 03:00:00
 ```

Currently has this ERS test in the queue.

Do not merge until `user_nl_*` file settings have been settled.