### PR TITLE
Set 'cosp' flag by default in active atm

### DIFF
--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -46,7 +46,7 @@
     <default_value></default_value>
     <values modifier='additive'>
       <value compset=""                >-mach $MACH</value>
-      <value compset="_EAM"            >-phys default</value>
+      <value compset="_EAM"            >-phys default -cosp</value>
       <value compset="_EAM%CMIP6_"     >&eam_phys_defaults; &eam_chem_defaults;</value>
       <value compset="_EAM%AR5sf"      >&eam_phys_defaults; -chem superfast_mam4_resus_mom_soag -rain_evap_to_coarse_aero</value>
       <value compset="_ELM%[^_]*BC"    >-bc_dep_to_snow_updates</value>


### PR DESCRIPTION
This adds the -cosp flag for when EAM is active.

Removes the need for the command 
`./xmlchange -file env_build.xml -id CAM_CONFIG_OPTS --append --val='-cosp'`
in run scripts before building.