### PR TITLE
Add latitude dependent background diffusivity/viscosity

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -717,7 +717,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_cvmix_background_scheme" type="char*1024"
 	category="cvmix" group="cvmix">
-Scheme for background diffusivity, 'constant' for constant with depth and space, 'BryanLewis' for vertically variable, 'none' for no background diffusivity
+Scheme for background diffusivity, 'constant' for constant with depth and space, 'BryanLewis' for vertically variable, 'LatDep' for latitude dependent, 'none' for no background diffusivity
 
 Valid values: 'constant', 'BryanLewis', and 'none'
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -719,7 +719,7 @@ Default: Defined in namelist_defaults.xml
 	category="cvmix" group="cvmix">
 Scheme for background diffusivity, 'constant' for constant with depth and space, 'BryanLewis' for vertically variable, 'LatDep' for latitude dependent, 'none' for no background diffusivity
 
-Valid values: 'constant', 'BryanLewis', and 'none'
+Valid values: 'constant', 'BryanLewis', 'LatDep', and 'none'
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -452,8 +452,8 @@
 					possible_values="Any non-negative real value."
 		/>
 		<nml_option name="config_cvmix_background_scheme" type="character" default_value="constant" units="NA"
-					description="Scheme for background diffusivity, 'constant' for constant with depth and space, 'BryanLewis' for vertically variable, 'none' for no background diffusivity"
-					possible_values="'constant', 'BryanLewis', and 'none'"
+					description="Scheme for background diffusivity, 'constant' for constant with depth and space, 'BryanLewis' for vertically variable, 'LatDep' for latitudinally varying, 'none' for no background diffusivity"
+					possible_values="'constant', 'BryanLewis', 'LatDep', and 'none'"
 		/>
 		<nml_option name="config_cvmix_background_diffusion" type="real" default_value="1.0e-5" units="m^2 s^{-1}"
 					description="Background vertical diffusion applied to tracer quantities"

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -71,7 +71,8 @@ module ocn_vmix_cvmix
    integer, parameter ::                 & ! supported cvmix background schemes
       cvmixBackgroundTypeNone = 0,       & ! no background scheme
       cvmixBackgroundTypeConstant = 1,   & ! Constant background scheme
-      cvmixBackgroundTypeBryanLewis = 2    ! Bryan Lewis background scheme
+      cvmixBackgroundTypeBryanLewis = 2, & ! Bryan Lewis background scheme
+      cvmixBackgroundTypeLatDep = 3        ! Latitude Dependent background scheme
 
    integer :: cvmixShearMixingChoice       ! user choice of vmix shear mixing scheme
 
@@ -79,7 +80,6 @@ module ocn_vmix_cvmix
       cvmixShearMixingTypePP = 1,        & ! PP mixing scheme
       cvmixShearMixingTypeKPP = 2          ! KPP mixing scheme
 
-   character(len=256) :: tmpstr
    integer :: myunit
 
 !***********************************************************************
@@ -174,6 +174,7 @@ contains
 
       real (kind=RKIND) :: latCellDeg, latCellDegAbs
       real (kind=RKIND),allocatable,save :: bdlatfn(:)
+      logical :: debug_bdlatfn = .false.
       logical,save :: first_call = .true.
 
       !-----------------------------------------------------------------
@@ -255,36 +256,30 @@ contains
 
       nCells = nCellsArray( 3 )
 
-      if (first_call) then
+      if (first_call .and. cvmixBackgroundChoice == cvmixBackgroundTypeLatDep) then
          allocate(bdlatfn(nCells))
          bdlatfn(:) = -999.0_RKIND
-         write(myunit,'(a,2g12.4)') 'tcx0 ',config_cvmix_background_viscosity,config_cvmix_background_diffusion
-         write(tmpstr,'(a,2g12.4)') 'tcx0 ',config_cvmix_background_viscosity,config_cvmix_background_diffusion
-         call mpas_log_write(trim(tmpstr),MPAS_LOG_OUT)
+         if (debug_bdlatfn) then
+            write(myunit,'(a,2g12.4)') 'tcx0 ',config_cvmix_background_viscosity,config_cvmix_background_diffusion
+         endif
          do iCell = 1, nCells
             ! Lat function for background visc/diff
             ! tcraig, is PI not defined to more than 3 digits in mpas-ocean???
             latCellDeg = latCell(iCell) * 180.0_RKIND / 3.14_RKIND
             latCellDegAbs = abs(latCellDeg)
             if (latCellDegAbs < 5.0_RKIND) then
-               call mpas_log_write('tcxL0',MPAS_LOG_OUT)
                bdlatfn(iCell) = 0.0_RKIND
             elseif (latCellDegAbs >= 5.0_RKIND .and. latCellDegAbs <= 27._RKIND) then
-               call mpas_log_write('tcxL5',MPAS_LOG_OUT)
                bdlatfn(iCell) = (1.0_RKIND-exp(-((latCellDegAbs-5._RKIND)/8._RKIND)**2))
             elseif (latCellDegAbs > 27.0_RKIND .and. latCellDegAbs <= 30._RKIND) then
-               call mpas_log_write('tcxL27',MPAS_LOG_OUT)
                bdlatfn(iCell) = 1.0_RKIND
             elseif (latCellDegAbs > 30._RKIND) then
-               call mpas_log_write('tcxL30',MPAS_LOG_OUT)
                bdlatfn(iCell) = 0.75_RKIND*(exp(-((latCellDegAbs-30._RKIND)**2)/36._RKIND)) + 0.25_RKIND
             endif
-            write(myunit,'(a,i8,2g12.4)') 'tcx1 ',iCell,lonCell(iCell),latCell(iCell)
-            write(tmpstr,'(a,i8,2g12.4)') 'tcx1 ',iCell,lonCell(iCell),latCell(iCell)
-            call mpas_log_write(trim(tmpstr),MPAS_LOG_OUT)
-            write(myunit,'(a,i8,2g12.4)') 'tcx2 ',iCell,latCellDeg,bdlatfn(iCell)
-            write(tmpstr,'(a,i8,2g12.4)') 'tcx2 ',iCell,latCellDeg,bdlatfn(iCell)
-            call mpas_log_write(trim(tmpstr),MPAS_LOG_OUT)
+            if (debug_bdlatfn) then
+               write(myunit,'(a,i8,2g12.4)') 'tcx1 ',iCell,lonCell(iCell),latCell(iCell)
+               write(myunit,'(a,i8,2g12.4)') 'tcx2 ',iCell,latCellDeg,bdlatfn(iCell)
+            endif
          enddo
       endif
 
@@ -292,6 +287,17 @@ contains
       ! start by adding the mininum background values to the viscocity/diffusivity arrays
       !
       if (cvmixBackgroundChoice == cvmixBackgroundTypeConstant) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1, nCells
+            do k = 1, nVertLevelsP1
+               vertViscTopOfCell(k, iCell) = vertViscTopOfCell(k, iCell) + config_cvmix_background_viscosity
+               vertDiffTopOfCell(k, iCell) = vertDiffTopOfCell(k, iCell) + config_cvmix_background_diffusion
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+      elseif (cvmixBackgroundChoice == cvmixBackgroundTypeLatDep) then
          !$omp parallel
          !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
@@ -924,6 +930,10 @@ contains
 
          cvmixBackgroundChoice = cvmixBackgroundTypeConstant
 
+      case ('latdep', 'Latdep', 'latdDep', 'LatDep', 'LATDEP')
+
+         cvmixBackgroundChoice = cvmixBackgroundTypeLatDep
+
       case ('bryanlewis', 'bryanLewis', 'BryanLewis', 'BRYANLEWIS')
 
          cvmixBackgroundChoice = cvmixBackgroundTypeBryanLewis
@@ -932,7 +942,7 @@ contains
 
          call mpas_log_write(&
             'Invalid choice for config_cvmix_background_scheme.  Choices are: none, &
-             &constant, BryanLewis')
+             &constant, BryanLewis, LatDep')
 
          err = 1
 
@@ -963,7 +973,8 @@ contains
       !
       ! initialize background mixing
       !
-      if ( cvmixBackgroundChoice == cvmixBackgroundTypeConstant ) then
+      if ( cvmixBackgroundChoice == cvmixBackgroundTypeConstant .or. &
+           cvmixBackgroundChoice == cvmixBackgroundTypeLatDep ) then
            call cvmix_init_bkgnd( &
                   bkgnd_Tdiff = config_cvmix_background_diffusion, &
                   bkgnd_Mdiff = config_cvmix_background_viscosity, &
@@ -976,7 +987,7 @@ contains
       if (config_use_cvmix_shear) then
         if (cvmixBackgroundChoice == cvmixBackgroundTypeNone .and. cvmixShearMixingChoice == cvmixShearMixingTypePP) then
             call mpas_log_write("config_use_cvmix_shear cannot be used with with config_cvmix_shear_mixing_scheme = 'PP'" &
-                 // "       without config_cvmix_background_scheme = 'constant' or 'BryanLewis'", MPAS_LOG_CRIT)
+                 // "       without config_cvmix_background_scheme = 'constant', 'LatDep', or 'BryanLewis'", MPAS_LOG_CRIT)
             err = 1
             return
         end if

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -79,6 +79,8 @@ module ocn_vmix_cvmix
       cvmixShearMixingTypePP = 1,        & ! PP mixing scheme
       cvmixShearMixingTypeKPP = 2          ! KPP mixing scheme
 
+   character(len=256) :: tmpstr
+
 !***********************************************************************
 
 contains
@@ -169,6 +171,10 @@ contains
 
       real (kind=RKIND) :: langmuirEnhancementFactor, langmuirNumber
 
+      real (kind=RKIND) :: latCellDeg, latCellDegAbs
+      real (kind=RKIND),allocatable,save :: bdlatfn(:)
+      logical,save :: first_call = .true.
+
       !-----------------------------------------------------------------
       !
       ! call relevant routines for computing mixing-related fields
@@ -248,6 +254,36 @@ contains
 
       nCells = nCellsArray( 3 )
 
+      if (first_call) then
+         allocate(bdlatfn(nCells))
+         bdlatfn(:) = -999.0_RKIND
+         write(tmpstr,'(a,2g12.4)') 'tcx0 ',config_cvmix_background_viscosity,config_cvmix_background_diffusion
+         call mpas_log_write(trim(tmpstr),MPAS_LOG_OUT)
+         do iCell = 1, nCells
+            ! Lat function for background visc/diff
+            ! tcraig, is PI not defined to more than 3 digits in mpas-ocean???
+            latCellDeg = latCell(iCell) * 180.0_RKIND / 3.14_RKIND
+            latCellDegAbs = abs(latCellDeg)
+            if (latCellDegAbs < 5.0_RKIND) then
+               call mpas_log_write('tcxL0',MPAS_LOG_OUT)
+               bdlatfn(iCell) = 0.0_RKIND
+            elseif (latCellDegAbs >= 5.0_RKIND .and. latCellDegAbs <= 27._RKIND) then
+               call mpas_log_write('tcxL5',MPAS_LOG_OUT)
+               bdlatfn(iCell) = (1.0_RKIND-exp(-((latCellDegAbs-5._RKIND)/8._RKIND)**2))
+            elseif (latCellDegAbs > 27.0_RKIND .and. latCellDegAbs <= 30._RKIND) then
+               call mpas_log_write('tcxL27',MPAS_LOG_OUT)
+               bdlatfn(iCell) = 1.0_RKIND
+            elseif (latCellDegAbs > 30._RKIND) then
+               call mpas_log_write('tcxL30',MPAS_LOG_OUT)
+               bdlatfn(iCell) = 0.75_RKIND*(exp(-((latCellDegAbs-30._RKIND)**2)/36._RKIND)) + 0.25_RKIND
+            endif
+            write(tmpstr,'(a,i8,2g12.4)') 'tcx1 ',iCell,lonCell(iCell),latCell(iCell)
+            call mpas_log_write(trim(tmpstr),MPAS_LOG_OUT)
+            write(tmpstr,'(a,i8,2g12.4)') 'tcx2 ',iCell,latCellDeg,bdlatfn(iCell)
+            call mpas_log_write(trim(tmpstr),MPAS_LOG_OUT)
+         enddo
+      endif
+
       !
       ! start by adding the mininum background values to the viscocity/diffusivity arrays
       !
@@ -256,8 +292,8 @@ contains
          !$omp do schedule(runtime) private(k)
          do iCell = 1, nCells
             do k = 1, nVertLevelsP1
-               vertViscTopOfCell(k, iCell) = vertViscTopOfCell(k, iCell) + config_cvmix_background_viscosity
-               vertDiffTopOfCell(k, iCell) = vertDiffTopOfCell(k, iCell) + config_cvmix_background_diffusion
+               vertViscTopOfCell(k, iCell) = vertViscTopOfCell(k, iCell) + bdlatfn(iCell)*config_cvmix_background_viscosity
+               vertDiffTopOfCell(k, iCell) = vertDiffTopOfCell(k, iCell) + bdlatfn(iCell)*config_cvmix_background_diffusion
             end do
          end do
          !$omp end do
@@ -796,6 +832,8 @@ contains
 
       deallocate(OBLDepths)
       deallocate(interfaceForcings)
+
+      first_call = .false.
 
    !--------------------------------------------------------------------
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -80,6 +80,7 @@ module ocn_vmix_cvmix
       cvmixShearMixingTypeKPP = 2          ! KPP mixing scheme
 
    character(len=256) :: tmpstr
+   integer :: myunit
 
 !***********************************************************************
 
@@ -257,6 +258,7 @@ contains
       if (first_call) then
          allocate(bdlatfn(nCells))
          bdlatfn(:) = -999.0_RKIND
+         write(myunit,'(a,2g12.4)') 'tcx0 ',config_cvmix_background_viscosity,config_cvmix_background_diffusion
          write(tmpstr,'(a,2g12.4)') 'tcx0 ',config_cvmix_background_viscosity,config_cvmix_background_diffusion
          call mpas_log_write(trim(tmpstr),MPAS_LOG_OUT)
          do iCell = 1, nCells
@@ -277,8 +279,10 @@ contains
                call mpas_log_write('tcxL30',MPAS_LOG_OUT)
                bdlatfn(iCell) = 0.75_RKIND*(exp(-((latCellDegAbs-30._RKIND)**2)/36._RKIND)) + 0.25_RKIND
             endif
+            write(myunit,'(a,i8,2g12.4)') 'tcx1 ',iCell,lonCell(iCell),latCell(iCell)
             write(tmpstr,'(a,i8,2g12.4)') 'tcx1 ',iCell,lonCell(iCell),latCell(iCell)
             call mpas_log_write(trim(tmpstr),MPAS_LOG_OUT)
+            write(myunit,'(a,i8,2g12.4)') 'tcx2 ',iCell,latCellDeg,bdlatfn(iCell)
             write(tmpstr,'(a,i8,2g12.4)') 'tcx2 ',iCell,latCellDeg,bdlatfn(iCell)
             call mpas_log_write(trim(tmpstr),MPAS_LOG_OUT)
          enddo
@@ -882,6 +886,7 @@ contains
       backgroundDiff = config_cvmix_background_diffusion
       cvmixConvectionOn = config_use_cvmix_convection
       cvmixKPPOn = config_use_cvmix_kpp
+      myunit = 1000 + domain % dminfo % my_proc_id
 
       !
       ! only initialize if CVMix is turned on


### PR DESCRIPTION
This adds a new option to the cvmix background scheme,

`config_cvmix_background_scheme = 'LatDep'
`

The background diffusivity and viscosity are implemented like "constant", but the constant values are then scaled inside the code.  config_cvmix_background_diffusion and
config_cvmix_background_viscosity specify the baseline background values.  The latitudinal dependence is hardwired into the code as specified by MV on 7/18/22.  The scaling factor varies between 0 and 1.  It is 0.25 above 42 degrees latitude, increases to 1 at 30 degrees latitude, then decreases to 0 between 27 degrees latitude and 5 degrees latitude.

This feature is fully backwards compatible.