### PR TITLE
Add pe layouts for Onyx for 10to60 grid

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -2379,7 +2379,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne30.+oi%oARRM60to10">
+  <grid name="a%ne30.+oi%oARRM60to10|a%ne30.+oi%ARRM10to60">
     <mach name="onyx|warhawk|blackbird">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="any">
         <comment>none</comment>

--- a/components/mpas-ocean/cime_config/config_pes.xml
+++ b/components/mpas-ocean/cime_config/config_pes.xml
@@ -503,7 +503,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%T62.+oi%oARRM60to10|a%TL319.+oi%oARRM60to10">
+  <grid name="a%T62.+oi%oARRM60to10|a%TL319.+oi%oARRM60to10|a%T62.+oi%ARRM10to60|a%TL319.+oi%ARRM10to60">
     <mach name="onyx|warhawk|blackbird">
       <pes compset=".*MPASCICE.+MPASO.+|.*MPASSI.+MPASO.+" pesize="any">
         <comment>none</comment>


### PR DESCRIPTION
I tested the --compset WCYCL1950 --res ne30pg2_ARRM10to60E2r1 and --compset GMPAS-JRA1p4 --res TL319_ARRM10to60E2r1 configurations on Onyx and both cases ran fine after this commit.  I used the latest "Running" document as a guide.  I also tested the LatDep background diffusivity option and it worked as expected.  Finally, I tested exact restart for these configurations by running 5+5 days and comparing the cpl restart file vs a 10 day run and those also passed.