### PR TITLE
Change default sea ice timestep in ARRM10to60E2r1 G-cases

### DIFF
--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -372,6 +372,7 @@
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS15to5">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oARRM60to10">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oARRM60to6">96</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%ARRM10to60">96</value>
       <value compset="_EAM.*_ELM.*MPASO">48</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne11np4">12</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne120np4">96</value>
@@ -484,6 +485,7 @@
       <value compset="_MPASO" grid="oi%oRRS15to5">96</value>
       <value compset="_MPASO" grid="oi%oARRM60to10">48</value>
       <value compset="_MPASO" grid="oi%oARRM60to6">48</value>
+      <value compset="_MPASO" grid="oi%ARRM10to60">48</value>
 
     </values>
     <group>run_coupling</group>


### PR DESCRIPTION
Changes the default coupling frequencies in G-cases so that the sea ice timestep is 15 minutes (rather than 30).

Prior to this, `ATM_NCPL` = 48 for all configurations with the `ARRM10to60E2r1` mesh (as first match), which would then set `config_dt = 1800` in MPAS-Seaice (overriding the default set in `components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml`).

Ran successful smoke test with `GMPAS-JRA1p4.TL319_ARRM10to60E2r1` and confirmed `config_dt = 900.0` in `mpassi_in`.  Ocean timestep remains unchanged (`config_dt = '00:10:00'`).

I also built a B-case `WCYCL1950.ne30pg2_ARRM10to60E2r1` to ensure timesteps didn't change there; `*_NCPL = 48` in `env_run.xml`, and `config_dt = 1800.0` in `mpassi_in`.
