### PR TITLE
Updates to support arcticx4v1pg2_ARRM10to60E2r1 configuration

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -2416,4 +2416,41 @@
       </pes>
     </mach>
   </grid>
+  <grid name="a%ne0np4_arcticx4.+oi%oARRM60to10|a%ne0np4_arcticx4.+oi%ARRM10to60">
+    <mach name="onyx|warhawk|blackbird|mustang|narwhal">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>2768</ntasks_atm>
+          <ntasks_lnd>160</ntasks_lnd>
+          <ntasks_rof>208</ntasks_rof>
+          <ntasks_ice>2400</ntasks_ice>
+          <ntasks_ocn>1200</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_cpl>2768</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>160</rootpe_rof>
+          <rootpe_ice>368</rootpe_ice>
+          <rootpe_ocn>2768</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
 </config_pes>

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -467,7 +467,7 @@
       <directive>-l select=1:ncpus=1</directive>
     </directives>
     <queues>
-      <queue walltimemax="00:29:00" nodemax="64" strict="true">debug</queue>
+      <queue walltimemax="00:30:00" nodemax="64" strict="true">debug</queue>
       <queue walltimemax="04:00:00" default="true">standard</queue>
       <queue default="true" walltimemax="12:00:00" jobmin="1" jobmax="1">transfer</queue>
     </queues>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -231,6 +231,8 @@ lnd/clm2/surfdata_map/surfdata_ne0np4_northamericax4v1.pg2_simyr2010_c210112.nc<
 lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2010_c210805.nc</fsurdat>
 <fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2000_c210707.nc</fsurdat>
+<fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="1950" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2000_c210707.nc</fsurdat>
 <fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr1850_c210707.nc</fsurdat>
 

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -390,6 +390,7 @@
       <value compset=".+" grid="a%ne1024np4">864</value>
       <value compset=".+" grid="a%ne0np4_arm_x8v3" >144</value>
       <value compset=".+" grid="a%ne0np4_conus_x4v1" >96</value>
+      <value compset=".+" grid="a%ne0np4_arcticx4v1">96</value>
       <value compset=".+" grid="a%ne0np4_northamericax4v1" >48</value>
       <value compset=".+" grid="a%ne0np4_antarcticax4v1" >48</value>
       <value compset=".+" grid="a%ne0np4_svalbard_x8v1" >144</value>
@@ -430,6 +431,7 @@
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne11np4">12</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne120np4">96</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="oi%oARRM60to10">48</value>
+      <value compset="_EAM.*_ELM.*MPASO" grid="a%ne0np4_arcticx4v1">$ATM_NCPL</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -486,6 +488,7 @@
       <value compset="_MPASO" grid="oi%oARRM60to10">48</value>
       <value compset="_MPASO" grid="oi%oARRM60to6">48</value>
       <value compset="_MPASO" grid="oi%ARRM10to60">48</value>
+      <value compset="_MPASO" grid="a%ne0np4_arcticx4v1">96</value>
 
     </values>
     <group>run_coupling</group>


### PR DESCRIPTION
- Update pe layout on DoD resources
- Add default 1950 elm fsurdat dataset
- Set NCPL to 96 for several components for this resolution