### PR TITLE
Add land files and settings for running historical and SSP simulations

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -233,15 +233,6 @@ lnd/clm2/surfdata_map/surfdata_ne0np4_northamericax4v1.pg2_simyr2010_c210112.nc<
 <!-- ne0np4_arcticx4v1.pg2 -->
 <finidat hgrid="ne0np4_arcticx4v1.pg2"  mask="oARRM60to10">lnd/clm2/initdata/arcticx4v1pg2_oARRM60to10.ICRUELM.spinup-from-interp.elm.r.0051-01-01-00000.nc</finidat>
 <finidat hgrid="ne0np4_arcticx4v1.pg2"  mask="ARRM10to60E2r1" sim_year="1950">lnd/clm2/initdata/20221017.ICRUELM-1950.arcticx4v1pg2_ARRM10to60E2r1.anvil.elm.r.0051-01-01-00000.nc</finidat>
-<fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="2010" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2010_c210805.nc</fsurdat>
-<fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="2000" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2000_c210707.nc</fsurdat>
-<fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="1950" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr1950_c221017.nc</fsurdat>
-<fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="1850" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr1850_c210707.nc</fsurdat>
-
 
 <!-- f10 resolution -->
 
@@ -369,6 +360,14 @@ lnd/clm2/surfdata_map/surfdata_nldas2_simyr2000_c181207.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_antarcticax4v1pg2_simyr1850_c210131.nc</fsurdat>
 <fsurdat hgrid="ne0np4_antarcticax4v1"        sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_antarcticax4v1pg2_simyr2010_c210131.nc</fsurdat>
+<fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="1850" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr1850_c210707.nc</fsurdat>
+<fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="1950" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr1950_c230615.nc</fsurdat>
+<fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="2010" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2010_c210805.nc</fsurdat>
+<fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="2000" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2000_c210707.nc</fsurdat>
 
 <fsurdat hgrid="1x1_tropicAtl" sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_1x1_tropicAtl_simyr1850_c130927.nc</fsurdat>
@@ -452,6 +451,12 @@ lnd/clm2/surfdata_map/surfdata_twpx4v1_simyr2000_c170706.nc</fsurdat>
  use_crop=".false."  >lnd/clm2/surfdata_map/surfdata.pftdyn_48x96_rcp8.5_simyr1850-2100_c130524.nc</flanduse_timeseries>
 <flanduse_timeseries hgrid="ne0np4_antarcticax4v1"    sim_year_range="1850-2015"
  use_crop=".false." >lnd/clm2/surfdata_map/landuse.timeseries_antarcticax4v1pg2_hist_simyr1850-2015_c210131.nc</flanduse_timeseries>
+<flanduse_timeseries hgrid="ne0np4_arcticx4v1.pg2"    sim_year_range="1950-2014" 
+ use_crop=".false." >lnd/clm2/surfdata_map/landuse.timeseries_arcticx4v1pg2_hist_simyr1950-2014_c230615.nc</flanduse_timeseries>
+<flanduse_timeseries hgrid="ne0np4_arcticx4v1.pg2"       rcp="3.0" sim_year_range="2015-2100"
+ use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_arcticx4v1pg2_rcp3.0_simyr2015-2100_c230615.nc</flanduse_timeseries>
+<flanduse_timeseries hgrid="ne0np4_arcticx4v1.pg2"       rcp="5.0" sim_year_range="2015-2100"
+ use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_arcticx4v1pg2_rcp5.0_simyr2015-2100_c230615.nc</flanduse_timeseries>
 
 <flanduse_timeseries hgrid="1x1_tropicAtl" sim_year_range="1850-2000"
  use_crop=".false."  >lnd/clm2/surfdata_map/surfdata.pftdyn_1x1_tropicAtl_hist_simyr1850-2005_c130627.nc</flanduse_timeseries>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -363,7 +363,7 @@ lnd/clm2/surfdata_map/surfdata_antarcticax4v1pg2_simyr2010_c210131.nc</fsurdat>
 <fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr1850_c210707.nc</fsurdat>
 <fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="1950" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr1950_c230615.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr1950_c221017.nc</fsurdat>
 <fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2010_c210805.nc</fsurdat>
 <fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="2000" use_crop=".false." >

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1324,7 +1324,7 @@ CLM datasets exist for years: 1000 (for testing), 1850, and 2000
 
 <entry id="sim_year_range" type="char*9" category="default_settings"
        group="default_settings" valid_values=
-"constant,1000-1002,1000-1004,850-1100,1100-1350,1350-1600,1600-1850,1850-2000,1850-2015,1850-2100,2000-2100,2015-2100">
+"constant,1000-1002,1000-1004,850-1100,1100-1350,1350-1600,1600-1850,1850-2000,1850-2015,1850-2100,1950-2014,2000-2100,2015-2100">
 Range of years to simulate transitory datasets for (such as dynamic: land-use datasets, aerosol-deposition, Nitrogen deposition rates etc.)
 Constant means simulation will be held at a constant year given in sim_year.
 A sim_year_range of 1000-1002 or 1000-1004 corresponds to data used for testing only, NOT corresponding to any real datasets.

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
@@ -35,6 +35,9 @@
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP3_RCP70_simyr2015_c220420.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP3_RCP70_simyr2015-2100_c211015.nc</flanduse_timeseries>
 
+<fsurdat hgrid="ne0np4_arcticx4v1.pg2">lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2010_c210805.nc</fsurdat>
+<flanduse_timeseries hgrid="ne0np4_arcticx4v1.pg2">lnd/clm2/surfdata_map/landuse.timeseries_arcticx4v1pg2_rcp3.0_simyr2015-2100_c230615.nc</flanduse_timeseries>
+
 <!-- Add following for hybrid run of SSP370 continuing from a historical simulation -->
 
 <check_finidat_fsurdat_consistency>.false.</check_finidat_fsurdat_consistency>

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
@@ -35,6 +35,9 @@
 <fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP5_RCP85_simyr2015_c220420.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP5_RCP85_simyr2015-2100_c220310.nc</flanduse_timeseries>
 
+<fsurdat hgrid="ne0np4_arcticx4v1.pg2">lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2010_c210805.nc</fsurdat>
+<flanduse_timeseries hgrid="ne0np4_arcticx4v1.pg2">lnd/clm2/surfdata_map/landuse.timeseries_arcticx4v1pg2_rcp5.0_simyr2015-2100_c230615.nc</flanduse_timeseries>
+
 <!-- Add following for hybrid run of SSP370 continuing from a historical simulation -->
 
 <check_finidat_fsurdat_consistency>.false.</check_finidat_fsurdat_consistency>

--- a/components/elm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
@@ -8,8 +8,10 @@
 <use_case_desc use_cn=".true." >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to 2005</use_case_desc>
 
 <sim_year>1850</sim_year>
-
 <sim_year_range>1850-2000</sim_year_range>
+
+<sim_year hgrid="ne0np4_arcticx4v1.pg2">1950</sim_year>
+<sim_year_range hgrid="ne0np4_arcticx4v1.pg2">1950-2014</sim_year_range>
 
 <clm_start_type>arb_ic</clm_start_type>
 

--- a/components/elm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
@@ -7,22 +7,20 @@
 <use_case_desc bgc="cndv" >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to 2005</use_case_desc>
 <use_case_desc use_cn=".true." >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to 2005</use_case_desc>
 
-<sim_year>1850</sim_year>
-<sim_year_range>1850-2000</sim_year_range>
-
+<!-- Anything hgrid specific setting of sim_year and sim_year_range should come first -->
 <sim_year hgrid="ne0np4_arcticx4v1.pg2">1950</sim_year>
 <sim_year_range hgrid="ne0np4_arcticx4v1.pg2">1950-2014</sim_year_range>
+
+<sim_year>1850</sim_year>
+<sim_year_range>1850-2000</sim_year_range>
 
 <clm_start_type>arb_ic</clm_start_type>
 
 <clm_demand >flanduse_timeseries</clm_demand>
 
-
-
 <stream_year_first_ndep phys="elm" use_cn=".true."   >1850</stream_year_first_ndep>
 <stream_year_last_ndep  phys="elm" use_cn=".true."   >2005</stream_year_last_ndep>
 <model_year_align_ndep  phys="elm" use_cn=".true."   >1850</model_year_align_ndep>
-
 
 <stream_year_first_pdep phys="elm" use_cn=".true."   >2000</stream_year_first_pdep>
 <stream_year_last_pdep  phys="elm" use_cn=".true."   >2000</stream_year_last_pdep>


### PR DESCRIPTION
This adds the land files needed to run a 1950-2014 historical simulation and SSP5.8.5 and 3.7.0 simulations using the atmosphere/land Arctic RRM mesh (arcticx4v1pg2).