### PR TITLE
Replace pbot with pslv as atmospheric coupling field

### DIFF
--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -65,7 +65,7 @@ module mpaso_cpl_indices
   integer :: index_x2o_Si_ifrac        ! fractional ice wrt ocean
   integer :: index_x2o_Si_bpress       ! ice basal pressure
   integer :: index_x2o_So_duu10n       ! 10m wind speed squared           (m^2/s^2)
-  integer :: index_x2o_Sa_pbot         ! atm bottom pressure              (Pa)
+  integer :: index_x2o_Sa_pslv         ! atmospheri sea level pressure    (Pa)
   integer :: index_x2o_Sa_co2prog      ! bottom atm level prognostic CO2
   integer :: index_x2o_Sa_co2diag      ! bottom atm level diagnostic CO2
   integer :: index_x2o_Foxx_taux       ! zonal wind stress (taux)         (W/m2   )
@@ -221,7 +221,7 @@ contains
 
     index_x2o_Si_ifrac      = mct_avect_indexra(x2o,'Si_ifrac')
     index_x2o_Si_bpress     = mct_avect_indexra(x2o,'Si_bpress')
-    index_x2o_Sa_pbot       = mct_avect_indexra(x2o,'Sa_pbot')
+    index_x2o_Sa_pslv       = mct_avect_indexra(x2o,'Sa_pslv')
     index_x2o_So_duu10n     = mct_avect_indexra(x2o,'So_duu10n')
     index_x2o_Foxx_tauy     = mct_avect_indexra(x2o,'Foxx_tauy')
     index_x2o_Foxx_taux     = mct_avect_indexra(x2o,'Foxx_taux')

--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -65,7 +65,7 @@ module mpaso_cpl_indices
   integer :: index_x2o_Si_ifrac        ! fractional ice wrt ocean
   integer :: index_x2o_Si_bpress       ! ice basal pressure
   integer :: index_x2o_So_duu10n       ! 10m wind speed squared           (m^2/s^2)
-  integer :: index_x2o_Sa_pslv         ! atmospheri sea level pressure    (Pa)
+  integer :: index_x2o_Sa_pslv         ! atmospheric sea level pressure   (Pa)
   integer :: index_x2o_Sa_co2prog      ! bottom atm level prognostic CO2
   integer :: index_x2o_Sa_co2diag      ! bottom atm level diagnostic CO2
   integer :: index_x2o_Foxx_taux       ! zonal wind stress (taux)         (W/m2   )

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -1568,7 +1568,7 @@ contains
 !    The following fields are sometimes received from the coupler,
 !      depending on model options:
 !
-!    o  pslv   -- sea level pressure                      (Pa)
+!    o  pslv   -- atmospheric pressure at sea level        (Pa)
 !    o  duu10n -- 10m wind speed squared                   (m^2/s^2)
 !    o  co2prog-- bottom atm level prognostic co2
 !    o  co2diag-- bottom atm level diagnostic co2

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -1567,8 +1567,8 @@ contains
 ! 
 !    The following fields are sometimes received from the coupler,
 !      depending on model options:
-! 
-!    o  pbot   -- bottom atm pressure                      (Pa)
+!
+!    o  pslv   -- sea level pressure                      (Pa)
 !    o  duu10n -- 10m wind speed squared                   (m^2/s^2)
 !    o  co2prog-- bottom atm level prognostic co2
 !    o  co2diag-- bottom atm level diagnostic co2
@@ -2031,7 +2031,7 @@ contains
            rainFlux(i) = x2o_o % rAttr(index_x2o_Faxa_rain, n)
         end if
         if ( atmosphericPressureField % isActive ) then
-           atmosphericPressure(i) = x2o_o % rAttr(index_x2o_Sa_pbot,   n)
+           atmosphericPressure(i) = x2o_o % rAttr(index_x2o_Sa_pslv,   n)
         end if
         if ( seaIcePressureField % isActive ) then
            ! Set seaIcePressure to be limited to 5m of pressure

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -1683,7 +1683,6 @@ contains
 !    o  u        -- bottom atm level zon wind
 !    o  v        -- bottom atm level mer wind
 !    o  tbot     -- bottom atm level temp
-!    o  pslv     -- atmospheric pressure at sea level
 !    o  ptem     -- bottom atm level pot temp
 !    o  shum     -- bottom atm level spec hum
 !    o  dens     -- bottom atm level air den

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -1683,7 +1683,7 @@ contains
 !    o  u        -- bottom atm level zon wind
 !    o  v        -- bottom atm level mer wind
 !    o  tbot     -- bottom atm level temp
-!    o  pbot     -- bottom atm level pressure
+!    o  pslv     -- atmospheric pressure at sea level
 !    o  ptem     -- bottom atm level pot temp
 !    o  shum     -- bottom atm level spec hum
 !    o  dens     -- bottom atm level air den

--- a/components/mpas-seaice/driver/mpassi_cpl_indices.F
+++ b/components/mpas-seaice/driver/mpassi_cpl_indices.F
@@ -71,7 +71,6 @@ module mpassi_cpl_indices
   integer :: index_x2i_Sa_u            ! bottom atm level zon wind
   integer :: index_x2i_Sa_v            ! bottom atm level mer wind
   integer :: index_x2i_Sa_tbot         ! bottom atm level temp
-  integer :: index_x2i_Sa_pslv         ! pressure at sea level
   integer :: index_x2i_Sa_ptem         ! bottom atm level pot temp
   integer :: index_x2i_Sa_shum         ! bottom atm level spec hum
   integer :: index_x2i_Sa_dens         ! bottom atm level air den
@@ -200,7 +199,6 @@ contains
     index_x2i_Sa_v          = mct_avect_indexra(x2i,'Sa_v')
     index_x2i_Sa_tbot       = mct_avect_indexra(x2i,'Sa_tbot')
     index_x2i_Sa_ptem       = mct_avect_indexra(x2i,'Sa_ptem')
-    index_x2i_Sa_pslv       = mct_avect_indexra(x2i,'Sa_pslv')
     index_x2i_Sa_shum       = mct_avect_indexra(x2i,'Sa_shum')
     index_x2i_Sa_dens       = mct_avect_indexra(x2i,'Sa_dens')
     index_x2i_So_dhdx       = mct_avect_indexra(x2i,'So_dhdx')

--- a/components/mpas-seaice/driver/mpassi_cpl_indices.F
+++ b/components/mpas-seaice/driver/mpassi_cpl_indices.F
@@ -71,7 +71,7 @@ module mpassi_cpl_indices
   integer :: index_x2i_Sa_u            ! bottom atm level zon wind
   integer :: index_x2i_Sa_v            ! bottom atm level mer wind
   integer :: index_x2i_Sa_tbot         ! bottom atm level temp
-  integer :: index_x2i_Sa_pbot         ! bottom atm level pressure
+  integer :: index_x2i_Sa_pslv         ! pressure at sea level
   integer :: index_x2i_Sa_ptem         ! bottom atm level pot temp
   integer :: index_x2i_Sa_shum         ! bottom atm level spec hum
   integer :: index_x2i_Sa_dens         ! bottom atm level air den
@@ -200,7 +200,7 @@ contains
     index_x2i_Sa_v          = mct_avect_indexra(x2i,'Sa_v')
     index_x2i_Sa_tbot       = mct_avect_indexra(x2i,'Sa_tbot')
     index_x2i_Sa_ptem       = mct_avect_indexra(x2i,'Sa_ptem')
-    index_x2i_Sa_pbot       = mct_avect_indexra(x2i,'Sa_pbot')
+    index_x2i_Sa_pslv       = mct_avect_indexra(x2i,'Sa_pslv')
     index_x2i_Sa_shum       = mct_avect_indexra(x2i,'Sa_shum')
     index_x2i_Sa_dens       = mct_avect_indexra(x2i,'Sa_dens')
     index_x2i_So_dhdx       = mct_avect_indexra(x2i,'So_dhdx')


### PR DESCRIPTION
Bringing over https://github.com/E3SM-Project/E3SM/pull/5999 to replace pressure variable used in atmospheric/ocean coupling.