### PR TITLE
changing cime submodule to point to master fork 20221219

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,8 +30,8 @@
 	branch = CESM_v2.1.4
 [submodule "cime"]
 	path = cime
-	url = git@github.com:darincomeau/cime.git
-	branch = E3SMv2.1-Arctic
+	url = git@github.com:ESMCI/cime.git
+	branch = master
 [submodule "externals/YAKL"]
 	path = externals/YAKL
 	url = git@github.com:mrnorman/YAKL.git


### PR DESCRIPTION
Changes cime submodule from branch on darincomeau fork to point to merge after https://github.com/ESMCI/cime/pull/4343.