### PR TITLE
Port to Carpenter

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -2733,7 +2733,7 @@
     </mach>
   </grid>
   <grid name="a%ne30np4.+_oi%EC30to60E2r2">
-    <mach name="onyx|warhawk|narwhal">
+    <mach name="onyx|warhawk|narwhal|carpenter">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*"  pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -2766,7 +2766,7 @@
     </mach>
   </grid>
   <grid name="a%ne30.+oi%oARRM60to10|a%ne30.+oi%ARRM10to60">
-    <mach name="onyx|warhawk|narwhal">
+    <mach name="onyx|warhawk|narwhal|carpenter">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -2803,7 +2803,7 @@
     </mach>
   </grid>
   <grid name="a%ne0np4_arcticx4.+oi%oARRM60to10|a%ne0np4_arcticx4.+oi%ARRM10to60">
-    <mach name="onyx|warhawk|narwhal">
+    <mach name="onyx|warhawk|narwhal|carpenter">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="any">
         <comment>none</comment>
         <ntasks>

--- a/cime_config/machines/cmake_macros/intel_carpenter.cmake
+++ b/cime_config/machines/cmake_macros/intel_carpenter.cmake
@@ -1,0 +1,8 @@
+string(APPEND FFLAGS " -fimf-use-svml -qno-openmp-simd")
+string(APPEND CFLAGS " -Wno-error=incompatible-function-pointer-types -Wno-error=implicit-function-declaration")
+if (NOT DEBUG)
+  string(APPEND FFLAGS " -qno-opt-dynamic-align")
+endif()
+string(APPEND SLIBS " -Wl,--as-needed,-L$ENV{NETCDF_DIR}/lib -lnetcdf")
+string(APPEND SLIBS " -mkl -lpthread")
+set(CXXFLAGS " -std=c++14 -fp-model precise -O2")

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -704,6 +704,29 @@
     </queues>
   </batch_system>
 
+  <batch_system MACH="carpenter" type="pbs" >
+    <directives queue="debug">
+      <directive>-A {{ PROJECT }}</directive>
+      <directive>-l application=Regional-Arctic-System-Model</directive>
+      <directive>-l select={{ num_nodes }}:ncpus={{ MAX_MPITASKS_PER_NODE }}:mpiprocs={{ tasks_per_node }}</directive>
+    </directives>
+    <directives queue="standard">
+      <directive>-A {{ PROJECT }}</directive>
+      <directive>-l application=Regional-Arctic-System-Model</directive>
+      <directive>-l select={{ num_nodes }}:ncpus={{ MAX_MPITASKS_PER_NODE }}:mpiprocs={{ tasks_per_node }}</directive>
+    </directives>
+    <directives queue="transfer">
+      <directive>-A {{ PROJECT }}</directive>
+      <directive>-l application=Regional-Arctic-System-Model</directive>
+      <directive>-l select=1:ncpus=1</directive>
+    </directives>
+    <queues>
+      <queue walltimemax="00:59:00" nodemax="72" strict="true">debug</queue>
+      <queue walltimemax="04:00:00" default="true">standard</queue>
+      <queue default="true" walltimemax="12:00:00" jobmin="1" jobmax="1">transfer</queue>
+    </queues>
+  </batch_system>
+
   <batch_system MACH="narwhal" type="pbs" >
     <directives queue="debug">
       <directive>-A {{ PROJECT }}</directive>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -4403,6 +4403,7 @@
     <MAX_TASKS_PER_NODE>44</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>44</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
+      <aprun_mode>override</aprun_mode>
       <executable>aprun</executable>
       <arguments>
         <arg name="num_tasks">-n {{ total_tasks }}</arg>
@@ -4512,6 +4513,7 @@
     <MAX_TASKS_PER_NODE>192</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>192</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
+      <aprun_mode>override</aprun_mode>
       <executable>aprun</executable>
       <arguments>
         <arg name="num_tasks">-n {{ total_tasks }}</arg>
@@ -4617,6 +4619,7 @@
     <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
+      <aprun_mode>override</aprun_mode>
       <executable>aprun</executable>
       <arguments>
         <arg name="num_tasks">-n {{ total_tasks }}</arg>
@@ -4794,6 +4797,7 @@
     <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
+      <aprun_mode>default</aprun_mode>
       <executable>aprun</executable>
       <arguments>
         <arg name="num_tasks">-n {{ total_tasks }}</arg>
@@ -4893,6 +4897,7 @@
     <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
+      <aprun_mode>override</aprun_mode>
       <executable>aprun</executable>
       <arguments>
         <arg name="num_tasks">-n {{ total_tasks }}</arg>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -4490,6 +4490,110 @@
     </environment_variables>
   </machine>
 
+  <machine MACH="carpenter">
+    <DESC>ERDC HPE Cray EX4000 AMD, 192 pes/node, batch system is PBS</DESC>
+    <NODENAME_REGEX>onyx</NODENAME_REGEX>
+    <OS>CNL</OS>
+    <COMPILERS>intel</COMPILERS>
+    <MPILIBS>mpich</MPILIBS>
+    <CHARGE_ACCOUNT>NPSCA07935242</CHARGE_ACCOUNT>
+    <SAVE_TIMING_DIR>/p/app/unsupported/RASM/acme</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>$ENV{WORKDIR}</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/p/app/unsupported/RASM/acme/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/p/app/unsupported/RASM/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/p/app/unsupported/RASM/acme/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/p/app/unsupported/RASM/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <TESTS>e3sm_developer</TESTS>
+    <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
+    <SUPPORTED_BY>rasm</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>192</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>192</MAX_MPITASKS_PER_NODE>
+    <mpirun mpilib="default">
+      <executable>aprun</executable>
+      <arguments>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+        <arg name="tasks_per_node">-N $SHELL{if [ `./xmlquery --value MAX_MPITASKS_PER_NODE` -gt `./xmlquery --value TOTAL_TASKS` ];then echo `./xmlquery --value TOTAL_TASKS`;else echo `./xmlquery --value MAX_MPITASKS_PER_NODE`;fi;}</arg>
+        <arg name="hyperthreading">--cc depth -d $SHELL{echo `./xmlquery --value MAX_TASKS_PER_NODE`/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc} -j $SHELL{if [ 64 -ge `./xmlquery --value MAX_TASKS_PER_NODE` ];then echo 1;else echo `./xmlquery --value MAX_TASKS_PER_NODE`/64|bc;fi;}</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="perl">/opt/cray/pe/modules/3.2.11.7/init/perl.pm</init_path>
+      <init_path lang="python">/opt/cray/pe/modules/3.2.11.7/init/python.py</init_path>
+      <init_path lang="sh">/opt/cray/pe/modules/3.2.11.7/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/modules/3.2.11.7/init/csh</init_path>
+      <cmd_path lang="perl">/opt/cray/pe/modules/3.2.11.7/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="python">/opt/cray/pe/modules/3.2.11.7/bin/modulecmd python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="rm">PrgEnv-intel</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">PrgEnv-pgi</command>
+        <command name="rm">intel</command>
+        <command name="rm">cce</command>
+        <command name="rm">gcc</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">cray-parallel-hdf5</command>
+        <command name="rm">pmi</command>
+        <command name="rm">cray-libsci</command>
+        <command name="rm">cray-mpich2</command>
+        <command name="rm">cray-mpich</command>
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
+        <command name="rm">craype</command>
+        <command name="rm">papi</command>
+        <command name="rm">cray-petsc</command>
+        <command name="rm">cray-libsci</command>
+        <command name="rm">esmf</command>
+        <command name="rm">craype</command>
+      </modules>
+
+      <modules compiler="intel">
+        <command name="load">PrgEnv-intel/8.4.0</command>
+        <command name="rm">intel</command>
+        <command name="load">intel/2023.0.0</command>
+        <command name="rm">cray-mpich</command>
+        <command name="load">cray-mpich/8.1.26</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-hdf5-parallel</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">netcdf</command>
+        <command name="load">cray-netcdf/4.9.0.3</command>
+        <command name="load">cray-hdf5/1.12.2.3</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.3</command>
+      </modules>
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <environment_variables>
+      <env name="MPICH_ENV_DISPLAY">1</env>
+      <env name="MPICH_VERSION_DISPLAY">1</env>
+      <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
+      <env name="NETCDF_DIR">/opt/cray/pe/netcdf/4.9.0.3/INTEL/19.0</env>
+      <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
+
+      <env name="OMP_STACKSIZE">64M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
+
+      <!--env name="HDF5_DISABLE_VERSION_CHECK">2</env-->
+      <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
+    </environment_variables>
+    <environment_variables compiler="intel">
+      <env name="FORT_BUFFERED">yes</env>
+    </environment_variables>
+    <environment_variables compiler="intel18">
+      <env name="FORT_BUFFERED">yes</env>
+    </environment_variables>
+  </machine>
+
   <machine MACH="narwhal">
     <DESC>NavyDSRC Cray EX, os is CNL, 128 pes/node, batch system is PBS</DESC>
     <NODENAME_REGEX>narwhal</NODENAME_REGEX>

--- a/cime_config/machines/config_pio.xml
+++ b/cime_config/machines/config_pio.xml
@@ -279,6 +279,7 @@
   <entry id="CPL_PIO_TYPENAME">
     <values>
       <value mach="onyx">netcdf</value>
+      <value mach="carpenter">netcdf</value>
       <value mach="narwhal">netcdf</value>
       <value mach="warhawk">netcdf</value>
       <value mach="warhawkm">netcdf</value>

--- a/components/mpas-ocean/cime_config/config_pes.xml
+++ b/components/mpas-ocean/cime_config/config_pes.xml
@@ -531,7 +531,7 @@
     </mach>
   </grid>
   <grid name="a%T62.+oi%oEC60to30|a%TL319.+oi%oEC60to30|a%TL319.+oi%EC30to60">
-    <mach name="onyx|warhawk|narwhal">
+    <mach name="onyx|warhawk|narwhal|carpenter">
       <pes compset=".*MPASCICE.+MPASO.+|.*MPASSI.+MPASO.+" pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -568,7 +568,7 @@
     </mach>
   </grid>
   <grid name="a%T62.+oi%oARRM60to10|a%TL319.+oi%oARRM60to10|a%T62.+oi%ARRM10to60|a%TL319.+oi%ARRM10to60">
-    <mach name="onyx|warhawk|narwhal">
+    <mach name="onyx|warhawk|narwhal|carpenter">
       <pes compset=".*MPASCICE.+MPASO.+|.*MPASSI.+MPASO.+" pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -605,7 +605,7 @@
     </mach>
   </grid>
   <grid name="a%T62.+oi%oARRM60to6|a%TL319.+oi%oARRM60to6">
-    <mach name="onyx|warhawk|narwhal">
+    <mach name="onyx|warhawk|narwhal|carpenter">
       <pes compset=".*MPASCICE.+MPASO.+" pesize="any">
         <comment>none</comment>
         <ntasks>


### PR DESCRIPTION
This replaces #43 and works with the latest update to CIME with fixes to the aprun implementation.

This was tested on Carpenter, Narwhal, and Warhawk.