### PR TITLE
Adding WCYCL1950-4xCO2 compset

### DIFF
--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -66,6 +66,11 @@
 </compset>
 
 <compset>
+  <alias>WCYCL1950-4xCO2</alias>
+  <lname>1950SOI_EAM%CMIP6-4xCO2_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
   <alias>WCYCL20TR</alias>
   <lname>20TRSOI_EAM%CMIP6_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
 </compset>

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -722,6 +722,7 @@
       <value compset="^1850.+CMIP6"                             >284.317</value>
       <value compset="^1850.+CMIP6.+4xCO2"			>1137.268</value>
       <value compset="^1950.+CMIP6"                             >312.821</value>
+      <value compset="^1950.+CMIP6.+4xCO2"			>1137.268</value>
       <value compset="^2010.+CMIP6"                             >388.717</value>
       <value compset="^SSP585.+CMIP6"				>0.000001</value>
       <value compset="^SSP370.+CMIP6"                           >0.000001</value>


### PR DESCRIPTION
Adds a `WCYCL1950-4xCO2` compset.

Per group discussion, this uses 4x **1850** CO2 levels, to be consistent with standard 4xCO2 protocol. All other settings are 1950 conditions.