### PR TITLE
Update ports to DoD HPC hardware

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -2274,7 +2274,7 @@
     </mach>
   </grid>
   <grid name="a%ne30.+oi%oARRM60to10|a%ne30.+oi%ARRM10to60">
-    <mach name="onyx|warhawk|narwhal">
+    <mach name="onyx|warhawk|narwhal|blueback|carpenter">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC" pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -2311,18 +2311,18 @@
     </mach>
   </grid>
   <grid name="a%ne0np4_arcticx4.+oi%oARRM60to10|a%ne0np4_arcticx4.+oi%ARRM10to60">
-    <mach name="onyx|warhawk|narwhal">
+    <mach name="onyx|warhawk|narwhal|blueback|carpenter">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC" pesize="any">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>2768</ntasks_atm>
-          <ntasks_lnd>160</ntasks_lnd>
-          <ntasks_rof>208</ntasks_rof>
-          <ntasks_ice>2400</ntasks_ice>
-          <ntasks_ocn>1200</ntasks_ocn>
+          <ntasks_atm>4416</ntasks_atm>
+          <ntasks_lnd>3264</ntasks_lnd>
+          <ntasks_rof>1152</ntasks_rof>
+          <ntasks_ice>1152</ntasks_ice>
+          <ntasks_ocn>1320</ntasks_ocn>
           <ntasks_glc>1</ntasks_glc>
           <ntasks_wav>1</ntasks_wav>
-          <ntasks_cpl>2768</ntasks_cpl>
+          <ntasks_cpl>4416</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -2336,10 +2336,10 @@
         </nthrds>
         <rootpe>
           <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>160</rootpe_rof>
-          <rootpe_ice>368</rootpe_ice>
-          <rootpe_ocn>2768</rootpe_ocn>
+          <rootpe_lnd>1152</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>4416</rootpe_ocn>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>
           <rootpe_cpl>0</rootpe_cpl>

--- a/cime_config/machines/cmake_macros/intel_blueback.cmake
+++ b/cime_config/machines/cmake_macros/intel_blueback.cmake
@@ -1,0 +1,27 @@
+string(APPEND CONFIG_ARGS " --host=cray")
+if (COMP_NAME STREQUAL gptl)
+  string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
+endif()
+
+#set(MPICC "cc")
+#set(MPICXX "CC")
+#set(MPIFC "ftn")
+#set(SCC "icx")
+set(SCXX "icpx")
+#set(SFC "ifx")
+
+
+# fp-model source does not work on in mpicxx, this seems to be a compiler bug, need to manually switch to precise
+set(CMAKE_CXX_FLAGS " ") # hardcode it here to blank, then try to do same things as in intel.cmake
+if (compile_threaded)
+  string(APPEND CMAKE_CXX_FLAGS " -qopenmp")
+endif()
+string(APPEND CMAKE_CXX_FLAGS_DEBUG " -O0 -g")
+string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O2")
+string(APPEND CMAKE_CXX_FLAGS " -fp-model=precise") # and manually add precise
+#message(STATUS "ndk CXXFLAGS=${CXXFLAGS}")
+
+string(APPEND CMAKE_Fortran_FLAGS " -fp-model consistent -fimf-use-svml")
+string(APPEND CMAKE_CXX_FLAGS " -fp-model consistent")
+string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -qno-opt-dynamic-align")
+string(APPEND CMAKE_EXE_LINKER_FLAGS " -lpthread")

--- a/cime_config/machines/cmake_macros/intel_carpenter.cmake
+++ b/cime_config/machines/cmake_macros/intel_carpenter.cmake
@@ -1,0 +1,27 @@
+string(APPEND CONFIG_ARGS " --host=cray")
+if (COMP_NAME STREQUAL gptl)
+  string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
+endif()
+
+#set(MPICC "cc")
+#set(MPICXX "CC")
+#set(MPIFC "ftn")
+#set(SCC "icx")
+set(SCXX "icpx")
+#set(SFC "ifx")
+
+
+# fp-model source does not work on in mpicxx, this seems to be a compiler bug, need to manually switch to precise
+set(CMAKE_CXX_FLAGS " ") # hardcode it here to blank, then try to do same things as in intel.cmake
+if (compile_threaded)
+  string(APPEND CMAKE_CXX_FLAGS " -qopenmp")
+endif()
+string(APPEND CMAKE_CXX_FLAGS_DEBUG " -O0 -g")
+string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O2")
+string(APPEND CMAKE_CXX_FLAGS " -fp-model=precise") # and manually add precise
+#message(STATUS "ndk CXXFLAGS=${CXXFLAGS}")
+
+string(APPEND CMAKE_Fortran_FLAGS " -fp-model consistent -fimf-use-svml")
+string(APPEND CMAKE_CXX_FLAGS " -fp-model consistent")
+string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -qno-opt-dynamic-align")
+string(APPEND CMAKE_EXE_LINKER_FLAGS " -lpthread")

--- a/cime_config/machines/cmake_macros/intel_narwhal.cmake
+++ b/cime_config/machines/cmake_macros/intel_narwhal.cmake
@@ -1,3 +1,26 @@
+string(APPEND CONFIG_ARGS " --host=cray")
+if (COMP_NAME STREQUAL gptl)
+  string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
+endif()
+
+#set(MPICC "cc")
+#set(MPICXX "CC")
+#set(MPIFC "ftn")
+#set(SCC "icx")
+set(SCXX "icpx")
+#set(SFC "ifx")
+
+
+# fp-model source does not work on in mpicxx, this seems to be a compiler bug, need to manually switch to precise
+set(CMAKE_CXX_FLAGS " ") # hardcode it here to blank, then try to do same things as in intel.cmake
+if (compile_threaded)
+  string(APPEND CMAKE_CXX_FLAGS " -qopenmp")
+endif()
+string(APPEND CMAKE_CXX_FLAGS_DEBUG " -O0 -g")
+string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O2")
+string(APPEND CMAKE_CXX_FLAGS " -fp-model=precise") # and manually add precise
+#message(STATUS "ndk CXXFLAGS=${CXXFLAGS}")
+
 string(APPEND CMAKE_Fortran_FLAGS " -fp-model consistent -fimf-use-svml")
 string(APPEND CMAKE_CXX_FLAGS " -fp-model consistent")
 string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -qno-opt-dynamic-align")

--- a/cime_config/machines/cmake_macros/intel_warhawk.cmake
+++ b/cime_config/machines/cmake_macros/intel_warhawk.cmake
@@ -1,3 +1,26 @@
+string(APPEND CONFIG_ARGS " --host=cray")
+if (COMP_NAME STREQUAL gptl)
+  string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
+endif()
+
+#set(MPICC "cc")
+#set(MPICXX "CC")
+#set(MPIFC "ftn")
+#set(SCC "icx")
+set(SCXX "icpx")
+#set(SFC "ifx")
+
+
+# fp-model source does not work on in mpicxx, this seems to be a compiler bug, need to manually switch to precise
+set(CMAKE_CXX_FLAGS " ") # hardcode it here to blank, then try to do same things as in intel.cmake
+if (compile_threaded)
+  string(APPEND CMAKE_CXX_FLAGS " -qopenmp")
+endif()
+string(APPEND CMAKE_CXX_FLAGS_DEBUG " -O0 -g")
+string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O2")
+string(APPEND CMAKE_CXX_FLAGS " -fp-model=precise") # and manually add precise
+#message(STATUS "ndk CXXFLAGS=${CXXFLAGS}")
+
 string(APPEND CMAKE_Fortran_FLAGS " -fp-model consistent -fimf-use-svml")
 string(APPEND CMAKE_CXX_FLAGS " -fp-model consistent")
 string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -qno-opt-dynamic-align")

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -880,7 +880,30 @@
     </queues>
   </batch_system>
 
-  <batch_system MACH="narwhal" type="pbs" >
+  <batch_system MACH="carpenter" type="pbs" >
+    <directives queue="debug">
+      <directive>-A {{ PROJECT }}</directive>
+      <directive>-l application=Regional-Arctic-System-Model</directive>
+      <directive>-l select={{ num_nodes }}:ncpus={{ MAX_MPITASKS_PER_NODE }}:mpiprocs={{ tasks_per_node }}</directive>
+    </directives>
+    <directives queue="standard">
+      <directive>-A {{ PROJECT }}</directive>
+      <directive>-l application=Regional-Arctic-System-Model</directive>
+      <directive>-l select={{ num_nodes }}:ncpus={{ MAX_MPITASKS_PER_NODE }}:mpiprocs={{ tasks_per_node }}</directive>
+    </directives>
+    <directives queue="transfer">
+      <directive>-A {{ PROJECT }}</directive>
+      <directive>-l application=Regional-Arctic-System-Model</directive>
+      <directive>-l select=1:ncpus=1</directive>
+    </directives>
+    <queues>
+      <queue walltimemax="00:59:00" nodemax="72" strict="true">debug</queue>
+      <queue walltimemax="04:00:00" default="true">standard</queue>
+      <queue default="true" walltimemax="12:00:00" jobmin="1" jobmax="1">transfer</queue>
+    </queues>
+   </batch_system>
+
+   <batch_system MACH="narwhal" type="pbs" >
     <directives queue="debug">
       <directive>-A {{ PROJECT }}</directive>
       <directive>-l application=Regional-Arctic-System-Model</directive>

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -926,4 +926,15 @@
     </queues>
   </batch_system>
 
+  <batch_system MACH="blueback" type="nersc_slurm">
+    <directives>
+      <directive> --constraint=standard</directive>
+    </directives>
+    <queues>
+      <queue walltimemax="00:30:00" nodemin="1" nodemax="72" strict="true" default="true">debug</queue>
+      <queue walltimemax="04:00:00" nodemin="1" nodemax="256" strict="true">standard</queue>
+      <queue default="true" walltimemax="12:00:00" jobmin="1" jobmax="1">transfer</queue>
+    </queues>
+  </batch_system>
+  
 </config_batch>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -5538,6 +5538,116 @@ AMD EPYC 7713 64-Core (Milan) (256GB) and 4 nvidia A100'</DESC>
     </environment_variables>
   </machine>
 
+  <machine MACH="blueback">
+    <DESC>ERDC HPE Cray EX4000 AMD, 192 pes/node, batch system is SLURM</DESC>
+    <NODENAME_REGEX>blueback</NODENAME_REGEX>
+    <OS>CNL</OS>
+    <COMPILERS>intel</COMPILERS>
+    <MPILIBS>mpich</MPILIBS>
+    <PROJECT>navos96350pnr</PROJECT>
+    <SAVE_TIMING_DIR>/p/work1/projects/RASM/acme</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>$ENV{WORKDIR}</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/p/work1/projects/RASM/acme/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/p/work1/projects/RASM/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/p/work1/projects/RASM/acme/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/p/work1/projects/RASM/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <TESTS>e3sm_developer</TESTS>
+    <BATCH_SYSTEM>nersc_slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>rasm</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>192</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>192</MAX_MPITASKS_PER_NODE>
+    <mpirun mpilib="default">
+      <executable>srun</executable>
+      <arguments>
+        <arg name="label"> --label</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }} -N {{ num_nodes }}</arg>
+        <arg name="thread_count">-c $SHELL{echo 192/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
+        <arg name="binding"> $SHELL{if [ 128 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
+        <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="perl">/opt/cray/pe/modules/3.2.11.7/init/perl.pm</init_path>
+      <init_path lang="python">/opt/cray/pe/modules/3.2.11.7/init/python.py</init_path>
+      <init_path lang="sh">/opt/cray/pe/modules/3.2.11.7/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/modules/3.2.11.7/init/csh</init_path>
+      <cmd_path lang="perl">/opt/cray/pe/modules/3.2.11.7/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="python">/opt/cray/pe/modules/3.2.11.7/bin/modulecmd python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="rm">PrgEnv-intel</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">PrgEnv-pgi</command>
+        <command name="rm">intel</command>
+        <command name="rm">cce</command>
+        <command name="rm">gcc</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">cray-parallel-hdf5</command>
+        <command name="rm">pmi</command>
+        <command name="rm">cray-libsci</command>
+        <command name="rm">cray-mpich2</command>
+        <command name="rm">cray-mpich</command>
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
+        <command name="rm">craype</command>
+        <command name="rm">papi</command>
+        <command name="rm">cray-petsc</command>
+        <command name="rm">cray-libsci</command>
+        <command name="rm">esmf</command>
+        <command name="rm">craype</command>
+      </modules>
+
+      <modules compiler="intel">
+        <command name="load">PrgEnv-intel/8.5.0</command>
+        <command name="rm">intel</command>
+        <command name="load">intel/2023.2.0</command>
+        <command name="rm">cray-mpich</command>
+        <command name="load">cray-mpich/8.1.30</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-hdf5-parallel</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">netcdf</command>
+        <command name="load">cray-netcdf/4.9.0.13</command>
+        <command name="load">cray-hdf5/1.14.3.1</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.13</command>
+      </modules>
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <environment_variables>
+      <env name="NETCDF_PATH">$ENV{NETCDF_DIR}</env>
+      <env name="PNETCDF_PATH">$ENV{PNETCDF_DIR}</env>
+      <!-- cmake configure fails on hdf5 checks for unknown reasons-->
+      <env name="HDF5_ROOT"/>
+      <env name="MPICH_ENV_DISPLAY">1</env>
+      <env name="MPICH_VERSION_DISPLAY">1</env>
+      <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
+      <env name="NETCDF_DIR">/opt/cray/pe/netcdf/4.9.0.3/INTEL/19.0</env>
+      <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
+
+      <env name="OMP_STACKSIZE">64M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
+
+      <!--env name="HDF5_DISABLE_VERSION_CHECK">2</env-->
+      <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
+    </environment_variables>
+    <environment_variables compiler="intel">
+      <env name="FORT_BUFFERED">yes</env>
+    </environment_variables>
+    <environment_variables compiler="intel18">
+      <env name="FORT_BUFFERED">yes</env>
+    </environment_variables>
+  </machine>
+  
   <machine MACH="docker-scream">
     <DESC>Docker</DESC>
     <NODENAME_REGEX>docker</NODENAME_REGEX>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -5379,12 +5379,12 @@ AMD EPYC 7713 64-Core (Milan) (256GB) and 4 nvidia A100'</DESC>
       </arguments>
     </mpirun>
     <module_system type="module">
-      <init_path lang="perl">/opt/cray/pe/modules/3.2.11.5/init/perl.pm</init_path>
-      <init_path lang="python">/opt/cray/pe/modules/3.2.11.5/init/python.py</init_path>
-      <init_path lang="sh">/opt/cray/pe/modules/3.2.11.5/init/sh</init_path>
-      <init_path lang="csh">/opt/cray/pe/modules/3.2.11.5/init/csh</init_path>
-      <cmd_path lang="perl">/opt/cray/pe/modules/3.2.11.5/bin/modulecmd perl</cmd_path>
-      <cmd_path lang="python">/opt/cray/pe/modules/3.2.11.5/bin/modulecmd python</cmd_path>
+      <init_path lang="perl">/opt/cray/pe/modules/3.2.11.7/init/perl.pm</init_path>
+      <init_path lang="python">/opt/cray/pe/modules/3.2.11.7/init/python.py</init_path>
+      <init_path lang="sh">/opt/cray/pe/modules/3.2.11.7/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/modules/3.2.11.7/init/csh</init_path>
+      <cmd_path lang="perl">/opt/cray/pe/modules/3.2.11.7/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="python">/opt/cray/pe/modules/3.2.11.7/bin/modulecmd python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
@@ -5403,32 +5403,33 @@ AMD EPYC 7713 64-Core (Milan) (256GB) and 4 nvidia A100'</DESC>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/8.0.0</command>
+        <command name="load">PrgEnv-intel/8.3.3</command>
         <command name="rm">intel</command>
         <command name="rm">intel-classic</command>
-        <command name="load">intel-classic/2021.3.0</command>
+        <command name="load">intel-classic/2022.2.1</command>
         <command name="rm">cray-mpich</command>
-        <command name="load">cray-mpich/8.1.14</command>
-        <command name="load">cray-netcdf/4.7.4.7</command>
-        <command name="load">cray-hdf5/1.12.0.7</command>
-        <command name="load">cray-parallel-netcdf/1.12.1.7</command>
+        <command name="load">cray-mpich/8.1.21</command>
+        <command name="load">cray-netcdf/4.9.0.1</command>
+        <command name="load">cray-hdf5/1.12.2.1</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.1</command>
         <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/21.08.1.2</command>
+        <command name="load">cray-libsci/22.08.1.1</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
     <environment_variables>
+      <env name="NETCDF_PATH">$ENV{NETCDF_DIR}</env>
+      <env name="PNETCDF_PATH">$ENV{PNETCDF_DIR}</env>
+      <env name="HDF5_ROOT"/>
       <env name="MPICH_ENV_DISPLAY">1</env>
       <env name="MPICH_VERSION_DISPLAY">1</env>
-      <!--env name="NETCDF_DIR">/opt/cray/pe/netcdf/4.7.4.0/intel/19.1</env-->
+      <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
       <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
-
       <env name="OMP_STACKSIZE">64M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
-
       <!--env name="HDF5_DISABLE_VERSION_CHECK">2</env-->
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
     </environment_variables>
@@ -5632,11 +5633,9 @@ AMD EPYC 7713 64-Core (Milan) (256GB) and 4 nvidia A100'</DESC>
       <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
       <env name="NETCDF_DIR">/opt/cray/pe/netcdf/4.9.0.3/INTEL/19.0</env>
       <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
-
       <env name="OMP_STACKSIZE">64M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
-
       <!--env name="HDF5_DISABLE_VERSION_CHECK">2</env-->
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
     </environment_variables>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -5542,6 +5542,115 @@ AMD EPYC 7713 64-Core (Milan) (256GB) and 4 nvidia A100'</DESC>
     </environment_variables>
   </machine>
 
+  <machine MACH="carpenter">
+    <DESC>ERDC HPE Cray EX4000 AMD, 192 pes/node, batch system is PBS</DESC>
+    <NODENAME_REGEX>carpenter</NODENAME_REGEX>
+    <OS>CNL</OS>
+    <COMPILERS>intel</COMPILERS>
+    <MPILIBS>mpich</MPILIBS>
+    <CHARGE_ACCOUNT>NPSCA07935242</CHARGE_ACCOUNT>
+    <SAVE_TIMING_DIR>/p/app/unsupported/RASM/acme</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>$ENV{WORKDIR}</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/p/app/unsupported/RASM/acme/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/p/app/unsupported/RASM/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/p/app/unsupported/RASM/acme/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/p/app/unsupported/RASM/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <TESTS>e3sm_developer</TESTS>
+    <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
+    <SUPPORTED_BY>rasm</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>192</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>192</MAX_MPITASKS_PER_NODE>
+    <mpirun mpilib="default">
+      <aprun_mode>override</aprun_mode>
+      <executable>aprun</executable>
+      <arguments>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+        <arg name="tasks_per_node">-N $SHELL{if [ `./xmlquery --value MAX_MPITASKS_PER_NODE` -gt `./xmlquery --value TOTAL_TASKS` ];then echo `./xmlquery --value TOTAL_TASKS`;else echo `./xmlquery --value MAX_MPITASKS_PER_NODE`;fi;}</arg>
+        <arg name="hyperthreading">--cc depth -d $SHELL{echo `./xmlquery --value MAX_TASKS_PER_NODE`/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc} -j $SHELL{if [ 64 -ge `./xmlquery --value MAX_TASKS_PER_NODE` ];then echo 1;else echo `./xmlquery --value MAX_TASKS_PER_NODE`/64|bc;fi;}</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="perl">/opt/cray/pe/modules/3.2.11.7/init/perl.pm</init_path>
+      <init_path lang="python">/opt/cray/pe/modules/3.2.11.7/init/python.py</init_path>
+      <init_path lang="sh">/opt/cray/pe/modules/3.2.11.7/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/modules/3.2.11.7/init/csh</init_path>
+      <cmd_path lang="perl">/opt/cray/pe/modules/3.2.11.7/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="python">/opt/cray/pe/modules/3.2.11.7/bin/modulecmd python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="rm">PrgEnv-intel</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">PrgEnv-pgi</command>
+        <command name="rm">intel</command>
+        <command name="rm">cce</command>
+        <command name="rm">gcc</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">cray-parallel-hdf5</command>
+        <command name="rm">pmi</command>
+        <command name="rm">cray-libsci</command>
+        <command name="rm">cray-mpich2</command>
+        <command name="rm">cray-mpich</command>
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
+        <command name="rm">craype</command>
+        <command name="rm">papi</command>
+        <command name="rm">cray-petsc</command>
+        <command name="rm">cray-libsci</command>
+        <command name="rm">esmf</command>
+        <command name="rm">craype</command>
+      </modules>
+
+      <modules compiler="intel">
+        <command name="load">PrgEnv-intel/8.4.0</command>
+        <command name="rm">intel</command>
+        <command name="load">intel/2023.0.0</command>
+        <command name="rm">cray-mpich</command>
+        <command name="load">cray-mpich/8.1.26</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-hdf5-parallel</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">netcdf</command>
+        <command name="load">cray-netcdf/4.9.0.3</command>
+        <command name="load">cray-hdf5/1.12.2.3</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.3</command>
+      </modules>
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <environment_variables>
+      <env name="NETCDF_PATH">$ENV{NETCDF_DIR}</env>
+      <env name="PNETCDF_PATH">$ENV{PNETCDF_DIR}</env>
+      <!-- cmake configure fails on hdf5 checks for unknown reasons-->
+      <env name="HDF5_ROOT"/>
+      <env name="MPICH_ENV_DISPLAY">1</env>
+      <env name="MPICH_VERSION_DISPLAY">1</env>
+      <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
+      <env name="NETCDF_DIR">/opt/cray/pe/netcdf/4.9.0.3/INTEL/19.0</env>
+      <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
+
+      <env name="OMP_STACKSIZE">64M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
+
+      <!--env name="HDF5_DISABLE_VERSION_CHECK">2</env-->
+      <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
+    </environment_variables>
+    <environment_variables compiler="intel">
+      <env name="FORT_BUFFERED">yes</env>
+    </environment_variables>
+    <environment_variables compiler="intel18">
+      <env name="FORT_BUFFERED">yes</env>
+    </environment_variables>
+  </machine>
+
   <machine MACH="blueback">
     <DESC>ERDC HPE Cray EX4000 AMD, 192 pes/node, batch system is SLURM</DESC>
     <NODENAME_REGEX>blueback</NODENAME_REGEX>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -5501,33 +5501,36 @@ AMD EPYC 7713 64-Core (Milan) (256GB) and 4 nvidia A100'</DESC>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/8.0.0</command>
+        <command name="load">PrgEnv-intel/8.5.0</command>
         <command name="rm">intel</command>
-        <command name="load">intel-classic/2021.3.0</command>
+        <command name="rm">intel-classic</command>
+        <command name="load">intel-classic/2023.2.0</command>
         <command name="rm">cray-mpich</command>
-        <command name="load">cray-mpich/8.1.9</command>
-        <command name="load">cray-pals/1.0.17</command>
-        <command name="load">cray-netcdf/4.7.4.4</command>
-        <command name="load">cray-hdf5/1.12.0.4</command>
-        <command name="load">cray-parallel-netcdf/1.12.1.4</command>
+        <command name="load">cray-mpich/8.1.30</command>
+        <command name="load">cray-pals/1.2.11</command>
+        <command name="load">cray-netcdf/4.9.0.13</command>
+        <command name="load">cray-hdf5/1.14.3.1</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.13</command>
         <command name="rm">cray-libsci</command>
-        <command name="load">cmake/3.21.4</command>
-        <command name="load">cray-libsci/21.08.1.2</command>
+        <command name="load">cray-libsci/24.07.0</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
     <environment_variables>
+      <env name="NETCDF_PATH">$ENV{NETCDF_DIR}</env>
+      <env name="PNETCDF_PATH">$ENV{PNETCDF_DIR}</env>
+      <!-- cmake configure fails on hdf5 checks for unknown reasons-->
+      <env name="HDF5_ROOT"/>
       <env name="MPICH_ENV_DISPLAY">1</env>
       <env name="MPICH_VERSION_DISPLAY">1</env>
+      <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
       <!--env name="NETCDF_DIR">/opt/cray/pe/netcdf/4.7.4.0/intel/19.1</env-->
       <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
-
       <env name="OMP_STACKSIZE">64M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
-
       <!--env name="HDF5_DISABLE_VERSION_CHECK">2</env-->
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
     </environment_variables>

--- a/cime_config/machines/config_pio.xml
+++ b/cime_config/machines/config_pio.xml
@@ -281,6 +281,7 @@
       <value mach="onyx">netcdf</value>
       <value mach="narwhal">netcdf</value>
       <value mach="warhawk">netcdf</value>
+      <value mach="blueback">netcdf</value>
     </values>
   </entry>
 

--- a/cime_config/machines/config_pio.xml
+++ b/cime_config/machines/config_pio.xml
@@ -282,6 +282,7 @@
       <value mach="narwhal">netcdf</value>
       <value mach="warhawk">netcdf</value>
       <value mach="blueback">netcdf</value>
+      <value mach="carpenter">netcdf</value>
     </values>
   </entry>
 

--- a/components/mpas-ocean/cime_config/config_pes.xml
+++ b/components/mpas-ocean/cime_config/config_pes.xml
@@ -468,19 +468,19 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%T62.+oi%oEC60to30|a%TL319.+oi%oEC60to30">
-    <mach name="onyx|warhawk|narwhal">
+  <grid name="a%T62.+oi%oEC60to30|a%TL319.+oi%oEC60to30|a%TL319.+oi%EC30to60">
+    <mach name="onyx|warhawk|narwhal|carpenter|blueback">
       <pes compset=".*MPASCICE.+MPASO.+|.*MPASSI.+MPASO.+" pesize="any">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>64</ntasks_atm>
-          <ntasks_lnd>64</ntasks_lnd>
-          <ntasks_rof>64</ntasks_rof>
-          <ntasks_ice>256</ntasks_ice>
-          <ntasks_ocn>896</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>256</ntasks_cpl>
+          <ntasks_atm>96</ntasks_atm>
+          <ntasks_lnd>1</ntasks_lnd>
+          <ntasks_rof>96</ntasks_rof>
+          <ntasks_ice>768</ntasks_ice>
+          <ntasks_ocn>640</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_cpl>96</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -497,7 +497,7 @@
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_rof>0</rootpe_rof>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>256</rootpe_ocn>
+          <rootpe_ocn>768</rootpe_ocn>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>
           <rootpe_cpl>0</rootpe_cpl>
@@ -506,7 +506,7 @@
     </mach>
   </grid>
   <grid name="a%T62.+oi%oARRM60to10|a%TL319.+oi%oARRM60to10|a%T62.+oi%ARRM10to60|a%TL319.+oi%ARRM10to60">
-    <mach name="onyx|warhawk|narwhal">
+    <mach name="onyx|warhawk|narwhal|carpenter|blueback">
       <pes compset=".*MPASCICE.+MPASO.+|.*MPASSI.+MPASO.+" pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -543,7 +543,7 @@
     </mach>
   </grid>
   <grid name="a%T62.+oi%oARRM60to6|a%TL319.+oi%oARRM60to6">
-    <mach name="onyx|warhawk|narwhal">
+    <mach name="onyx|warhawk|narwhal|carpenter|blueback">
       <pes compset=".*MPASCICE.+MPASO.+" pesize="any">
         <comment>none</comment>
         <ntasks>

--- a/share/esmf_wrf_timemgr/ESMF_Stubs.F90
+++ b/share/esmf_wrf_timemgr/ESMF_Stubs.F90
@@ -141,10 +141,10 @@ CONTAINS
 
       IF ( PRESENT( rc ) ) rc = ESMF_SUCCESS
 #ifndef HIDE_MPI
-      CALL MPI_Finalize( ier )
-      IF ( ier .ne. mpi_success )THEN
-        IF ( PRESENT( rc ) ) rc = ESMF_FAILURE
-      END IF
+!tcx      CALL MPI_Finalize( ier )
+!      IF ( ier .ne. mpi_success )THEN
+!        IF ( PRESENT( rc ) ) rc = ESMF_FAILURE
+!      END IF
 #endif
    END SUBROUTINE ESMF_Finalize
 


### PR DESCRIPTION
Update/Add E3SMv3-Arctic hardware ports on Narwhal, Warhawk, and Blueback.

There is a change to ESMF_Stubs.F90.  On a few machines, the MPI_Finalize causes the job to abort.  I'm not sure if there is a conflict/overlap with another MPI_Finalize elsewhere or what's happening, but the jobs complete then don't exit gracefully.  Removing this call allows the job to complete gracefully.