### PR TITLE
Initial port to Barfoot, Add support for "netcdf,cdf5" mpas stream iotype

### DIFF
--- a/cime_config/machines/cmake_macros/intel_barfoot.cmake
+++ b/cime_config/machines/cmake_macros/intel_barfoot.cmake
@@ -1,0 +1,27 @@
+string(APPEND CONFIG_ARGS " --host=cray")
+if (COMP_NAME STREQUAL gptl)
+  string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
+endif()
+
+#set(MPICC "cc")
+#set(MPICXX "CC")
+#set(MPIFC "ftn")
+#set(SCC "icx")
+set(SCXX "icpx")
+#set(SFC "ifx")
+
+# fp-model source does not work on in mpicxx, this seems to be a compiler bug, need to manually switch to precise
+set(CMAKE_CXX_FLAGS " ") # hardcode it here to blank, then try to do same things as in intel.cmake
+if (compile_threaded)
+  string(APPEND CMAKE_CXX_FLAGS " -qopenmp")
+endif()
+string(APPEND CMAKE_CXX_FLAGS_DEBUG " -O0 -g")
+string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O2")
+string(APPEND CMAKE_CXX_FLAGS " -fp-model=precise") # and manually add precise
+#message(STATUS "ndk CXXFLAGS=${CXXFLAGS}")
+
+string(APPEND CMAKE_Fortran_FLAGS " -fp-model consistent -fimf-use-svml")
+string(APPEND CMAKE_CXX_FLAGS " -fp-model consistent")
+string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -qno-opt-dynamic-align")
+string(APPEND CMAKE_EXE_LINKER_FLAGS " -lpthread")
+string(APPEND SPIO_CMAKE_OPTS " -DPIO_ENABLE_TOOLS:BOOL=OFF")

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -905,6 +905,29 @@
     </queues>
   </batch_system>
 
+  <batch_system MACH="barfoot" type="pbs" >
+    <directives queue="debug">
+      <directive>-A {{ PROJECT }}</directive>
+      <directive>-l application=Regional-Arctic-System-Model</directive>
+      <directive>-l select={{ num_nodes }}:ncpus={{ MAX_MPITASKS_PER_NODE }}:mpiprocs={{ tasks_per_node }}</directive>
+    </directives>
+    <directives queue="standard">
+      <directive>-A {{ PROJECT }}</directive>
+      <directive>-l application=Regional-Arctic-System-Model</directive>
+      <directive>-l select={{ num_nodes }}:ncpus={{ MAX_MPITASKS_PER_NODE }}:mpiprocs={{ tasks_per_node }}</directive>
+    </directives>
+    <directives queue="transfer">
+      <directive>-A {{ PROJECT }}</directive>
+      <directive>-l application=Regional-Arctic-System-Model</directive>
+      <directive>-l select=1:ncpus=1</directive>
+    </directives>
+    <queues>
+      <queue walltimemax="00:59:00" nodemax="72" strict="true">debug</queue>
+      <queue walltimemax="04:00:00" default="true">standard</queue>
+      <queue default="true" walltimemax="12:00:00" jobmin="1" jobmax="1">transfer</queue>
+    </queues>
+  </batch_system>
+
   <batch_system MACH="narwhal" type="nersc_slurm" >
     <directives>
       <directive> --constraint=standard</directive>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -5695,6 +5695,115 @@ AMD EPYC 7713 64-Core (Milan) (256GB) and 4 nvidia A100'</DESC>
     </environment_variables>
   </machine>
 
+  <machine MACH="barfoot">
+    <DESC>ERDC HPE Cray EX4000 AMD, 192 pes/node, batch system is PBS</DESC>
+    <NODENAME_REGEX>barfoot</NODENAME_REGEX>
+    <OS>CNL</OS>
+    <COMPILERS>intel</COMPILERS>
+    <MPILIBS>mpich</MPILIBS>
+    <CHARGE_ACCOUNT>NPSCA07935242</CHARGE_ACCOUNT>
+    <SAVE_TIMING_DIR>/p/global/Projects/RASM/acme</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>$ENV{WORKDIR}</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/p/global/Projects/RASM/acme/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/p/global/Projects/RASM/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/p/global/Projects/RASM/acme/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/p/global/Projects/RASM/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <TESTS>e3sm_developer</TESTS>
+    <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
+    <SUPPORTED_BY>rasm</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>192</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>192</MAX_MPITASKS_PER_NODE>
+    <mpirun mpilib="default">
+      <aprun_mode>override</aprun_mode>
+      <executable>aprun</executable>
+      <arguments>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+        <arg name="tasks_per_node">-N $SHELL{if [ `./xmlquery --value MAX_MPITASKS_PER_NODE` -gt `./xmlquery --value TOTAL_TASKS` ];then echo `./xmlquery --value TOTAL_TASKS`;else echo `./xmlquery --value MAX_MPITASKS_PER_NODE`;fi;}</arg>
+        <arg name="hyperthreading">--cc depth -d $SHELL{echo `./xmlquery --value MAX_TASKS_PER_NODE`/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc} -j $SHELL{if [ 64 -ge `./xmlquery --value MAX_TASKS_PER_NODE` ];then echo 1;else echo `./xmlquery --value MAX_TASKS_PER_NODE`/64|bc;fi;}</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="perl">/opt/cray/pe/modules/3.2.11.7/init/perl.pm</init_path>
+      <init_path lang="python">/opt/cray/pe/modules/3.2.11.7/init/python.py</init_path>
+      <init_path lang="sh">/opt/cray/pe/modules/3.2.11.7/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/modules/3.2.11.7/init/csh</init_path>
+      <cmd_path lang="perl">/opt/cray/pe/modules/3.2.11.7/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="python">/opt/cray/pe/modules/3.2.11.7/bin/modulecmd python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="rm">PrgEnv-intel</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">PrgEnv-pgi</command>
+        <command name="rm">intel</command>
+        <command name="rm">cce</command>
+        <command name="rm">gcc</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">cray-parallel-hdf5</command>
+        <command name="rm">pmi</command>
+        <command name="rm">cray-libsci</command>
+        <command name="rm">cray-mpich2</command>
+        <command name="rm">cray-mpich</command>
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
+        <command name="rm">craype</command>
+        <command name="rm">papi</command>
+        <command name="rm">cray-petsc</command>
+        <command name="rm">cray-libsci</command>
+        <command name="rm">esmf</command>
+        <command name="rm">craype</command>
+      </modules>
+
+      <modules compiler="intel">
+        <command name="load">PrgEnv-intel/8.6.0</command>
+        <command name="rm">intel</command>
+        <command name="load">intel/2023.0.0</command>
+        <command name="rm">cray-mpich</command>
+        <command name="load">cray-mpich/8.1.32</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-hdf5-parallel</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">netcdf</command>
+      </modules>
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <environment_variables>
+      <env name="NETCDF_PATH">/p/app/unsupported/netcdf/4.9.2-intel-2023.0.0</env>
+      <!--
+      <env name="PNETCDF_PATH">$ENV{PNETCDF_DIR}</env>
+      -->
+      <!-- cmake configure fails on hdf5 checks for unknown reasons-->
+      <env name="HDF5_ROOT"/>
+      <env name="MPICH_ENV_DISPLAY">1</env>
+      <env name="MPICH_VERSION_DISPLAY">1</env>
+      <env name="FI_CXI_RX_MATCH_MODE">software</env>
+      <env name="NETCDF_DIR">/p/app/unsupported/netcdf/4.9.2-intel-2023.0.0</env>
+      <env name="LD_LIBRARY_PATH">/app/unsupported/netcdf/4.9.2-intel-2023.0.0/lib:/app/unsupported/netcdf/4.9.2-intel-2023.0.0/lib:/app/unsupported/hdf5/1.14.3-intel-2023.0.0/lib:/app/unsupported/hdf4/4.2.16-2-nonetcdf-intel-2023.0.0/lib:/app/unsupported/szip/2.1.1-intel-2023.0.0/lib:/p/app/intel/oneapi_2023.0.0/mkl/2023.0.0/lib/intel64:$ENV{LD_LIBRARY_PATH}</env>
+      <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
+
+      <env name="OMP_STACKSIZE">64M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
+
+      <!--env name="HDF5_DISABLE_VERSION_CHECK">2</env-->
+      <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
+    </environment_variables>
+    <environment_variables compiler="intel">
+      <env name="FORT_BUFFERED">yes</env>
+    </environment_variables>
+    <environment_variables compiler="intel18">
+      <env name="FORT_BUFFERED">yes</env>
+    </environment_variables>
+  </machine>
+
   <machine MACH="blueback">
     <DESC>ERDC HPE Cray EX4000 AMD, 192 pes/node, batch system is SLURM</DESC>
     <NODENAME_REGEX>blueback</NODENAME_REGEX>

--- a/cime_config/machines/config_pio.xml
+++ b/cime_config/machines/config_pio.xml
@@ -67,6 +67,7 @@
       <value mach="chicoma-gpu">netcdf</value>
       <value mach="bebop" mpilib="impi" compset=".*CAM5.+MPAS.*">netcdf</value>
       <value mach="fugaku" compiler="gnu">netcdf</value>
+      <value mach="barfoot">netcdf</value>
     </values>
   </entry>
 
@@ -280,6 +281,7 @@
     <values>
       <value mach="onyx">netcdf</value>
       <value mach="carpenter">netcdf</value>
+      <value mach="barfoot">netcdf</value>
       <value mach="blueback">netcdf</value>
       <value mach="narwhal">netcdf</value>
       <value mach="warhawk">netcdf</value>

--- a/components/mpas-framework/src/driver/mpas_subdriver.F
+++ b/components/mpas-framework/src/driver/mpas_subdriver.F
@@ -283,6 +283,8 @@ module mpas_subdriver
          mesh_iotype = MPAS_IO_PNETCDF5
       else if (trim(iotype) == 'netcdf') then
          mesh_iotype = MPAS_IO_NETCDF
+      else if (trim(iotype) == 'netcdf,cdf5') then
+         mesh_iotype = MPAS_IO_NETCDF5
       else if (trim(iotype) == 'netcdf4') then
          mesh_iotype = MPAS_IO_NETCDF4
       else

--- a/components/mpas-framework/src/framework/mpas_io.F
+++ b/components/mpas-framework/src/framework/mpas_io.F
@@ -236,6 +236,7 @@ module mpas_io
          return 
       end if
       if (ioformat /= MPAS_IO_NETCDF .and. &
+          ioformat /= MPAS_IO_NETCDF5 .and. &
           ioformat /= MPAS_IO_NETCDF4 .and. &
           ioformat /= MPAS_IO_PNETCDF .and. &
           ioformat /= MPAS_IO_PNETCDF5 .and. &
@@ -275,6 +276,9 @@ module mpas_io
          else if (ioformat == MPAS_IO_NETCDF) then
             pio_iotype = PIO_iotype_netcdf
             pio_mode = PIO_64BIT_OFFSET
+         else if (ioformat == MPAS_IO_NETCDF5) then
+            pio_iotype = PIO_iotype_netcdf
+            pio_mode = PIO_64BIT_DATA
          else if (ioformat == MPAS_IO_NETCDF4) then
             pio_iotype = PIO_iotype_netcdf4p
 #ifdef USE_PIO2

--- a/components/mpas-framework/src/framework/mpas_io_types.inc
+++ b/components/mpas-framework/src/framework/mpas_io_types.inc
@@ -10,10 +10,11 @@
 
    ! I/O formats
    integer, parameter :: MPAS_IO_NETCDF   = 3, &
-                         MPAS_IO_PNETCDF  = 4, &
-                         MPAS_IO_NETCDF4  = 5, &
-                         MPAS_IO_PNETCDF5 = 6, &
-                         MPAS_IO_ADIOS    = 7
+                         MPAS_IO_NETCDF5  = 35, &
+                         MPAS_IO_NETCDF4  = 4, &
+                         MPAS_IO_PNETCDF  = 5, &
+                         MPAS_IO_PNETCDF5 = 55, &
+                         MPAS_IO_ADIOS    = 6
 
    ! Field and attribute types
    integer, parameter :: MPAS_IO_REAL     =  8,  &

--- a/components/mpas-framework/src/framework/mpas_stream_manager.F
+++ b/components/mpas-framework/src/framework/mpas_stream_manager.F
@@ -5892,7 +5892,8 @@ subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filena
     use mpas_derived_types, only : MPAS_LOG_ERR
     use mpas_log
     use mpas_io, only : MPAS_IO_SINGLE_PRECISION, MPAS_IO_DOUBLE_PRECISION, MPAS_IO_NATIVE_PRECISION, &
-                        MPAS_IO_NETCDF, MPAS_IO_PNETCDF, MPAS_IO_NETCDF4, MPAS_IO_PNETCDF5, MPAS_IO_ADIOS
+                        MPAS_IO_NETCDF, MPAS_IO_NETCDF5, MPAS_IO_NETCDF4, &
+                        MPAS_IO_PNETCDF, MPAS_IO_PNETCDF5, MPAS_IO_ADIOS
 
     implicit none
 
@@ -5961,6 +5962,8 @@ subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filena
        iotype = MPAS_IO_NETCDF4
     else if (iotype_c == 4) then
        iotype = MPAS_IO_ADIOS
+    else if (iotype_c == 5) then
+       iotype = MPAS_IO_NETCDF5
     else
        iotype = MPAS_IO_PNETCDF
     end if

--- a/components/mpas-framework/src/framework/xml_stream_parser.c
+++ b/components/mpas-framework/src/framework/xml_stream_parser.c
@@ -1276,6 +1276,11 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "I/O type:", "NetCDF-4/HDF5");
 				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
 			}
+			else if (strstr(iotype, "netcdf,cdf5") != NULL) {
+				i_iotype = 5;
+				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "I/O type:", "Serial NetCDF (CDF-5, large variable support)");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
 			else if (strstr(iotype, "netcdf") != NULL) {
 				i_iotype = 2;
 				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "I/O type:", "Serial NetCDF");
@@ -1609,6 +1614,11 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			else if (strstr(iotype, "netcdf4") != NULL) {
 				i_iotype = 3;
 				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "I/O type:", "NetCDF-4/HDF5");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+			else if (strstr(iotype, "netcdf,cdf5") != NULL) {
+				i_iotype = 5;
+				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "I/O type:", "Serial NetCDF (CDF-5, large variable support)");
 				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
 			}
 			else if (strstr(iotype, "netcdf") != NULL) {
@@ -2010,6 +2020,11 @@ void xml_stream_get_attributes(char *fname, char *streamname, int *mpi_comm, cha
 				else if (strstr(xml_iotype, "netcdf4") != NULL) {
 					sprintf(io_type, "%s", xml_iotype);
 					snprintf(msgbuf, MSGSIZE, "Using io_type NetCDF-4/HDF5 for mesh stream");
+					mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+				}
+				else if (strstr(xml_iotype, "netcdf,cdf5") != NULL) {
+					sprintf(io_type, "%s", xml_iotype);
+					snprintf(msgbuf, MSGSIZE, "Using io_type Serial NetCDF (CDF-5, large variable support) for mesh stream");
 					mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
 				}
 				else if (strstr(xml_iotype, "netcdf") != NULL) {

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -578,7 +578,8 @@ def buildnml(case, caseroot, compname):
             lines.append('                  type="none"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-                lines.append('                  io_type="pnetcdf,cdf5"')
+#                lines.append('                  io_type="pnetcdf,cdf5"')
+                lines.append('                  io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('                  io_type="{}"'.format(ocn_pio_typename))
 
@@ -588,7 +589,8 @@ def buildnml(case, caseroot, compname):
             lines.append('                  type="input"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-                lines.append('                  io_type="pnetcdf,cdf5"')
+#                lines.append('                  io_type="pnetcdf,cdf5"')
+                lines.append('                  io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('                  io_type="{}"'.format(ocn_pio_typename))
 
@@ -610,7 +612,8 @@ def buildnml(case, caseroot, compname):
             lines.append('                  type="input;output"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-                lines.append('                  io_type="pnetcdf,cdf5"')
+#                lines.append('                  io_type="pnetcdf,cdf5"')
+                lines.append('                  io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('                  io_type="{}"'.format(ocn_pio_typename))
 
@@ -630,7 +633,8 @@ def buildnml(case, caseroot, compname):
             lines.append('        type="output"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-                lines.append('        io_type="pnetcdf,cdf5"')
+#                lines.append('        io_type="pnetcdf,cdf5"')
+                lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
 
@@ -942,7 +946,8 @@ def buildnml(case, caseroot, compname):
             lines.append('        precision="single"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-                lines.append('        io_type="pnetcdf,cdf5"')
+#                lines.append('        io_type="pnetcdf,cdf5"')
+                lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
 
@@ -1327,7 +1332,8 @@ def buildnml(case, caseroot, compname):
             lines.append('        precision="single"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-                lines.append('        io_type="pnetcdf,cdf5"')
+#                lines.append('        io_type="pnetcdf,cdf5"')
+                lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
 
@@ -1564,7 +1570,8 @@ def buildnml(case, caseroot, compname):
             lines.append('        precision="single"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-                lines.append('        io_type="pnetcdf,cdf5"')
+#                lines.append('        io_type="pnetcdf,cdf5"')
+                lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
 
@@ -1630,7 +1637,8 @@ def buildnml(case, caseroot, compname):
             lines.append('        precision="single"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-                lines.append('        io_type="pnetcdf,cdf5"')
+#                lines.append('        io_type="pnetcdf,cdf5"')
+                lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
 
@@ -1737,7 +1745,8 @@ def buildnml(case, caseroot, compname):
             lines.append('        type="input;output"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-                lines.append('        io_type="pnetcdf,cdf5"')
+#                lines.append('        io_type="pnetcdf,cdf5"')
+                lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
 
@@ -1754,7 +1763,8 @@ def buildnml(case, caseroot, compname):
             lines.append('        type="input;output"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-                lines.append('        io_type="pnetcdf,cdf5"')
+#                lines.append('        io_type="pnetcdf,cdf5"')
+                lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
 
@@ -1771,7 +1781,8 @@ def buildnml(case, caseroot, compname):
             lines.append('        type="input;output"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-                lines.append('        io_type="pnetcdf,cdf5"')
+#                lines.append('        io_type="pnetcdf,cdf5"')
+                lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
 

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -578,7 +578,6 @@ def buildnml(case, caseroot, compname):
             lines.append('                  type="none"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-#                lines.append('                  io_type="pnetcdf,cdf5"')
                 lines.append('                  io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('                  io_type="{}"'.format(ocn_pio_typename))
@@ -589,7 +588,6 @@ def buildnml(case, caseroot, compname):
             lines.append('                  type="input"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-#                lines.append('                  io_type="pnetcdf,cdf5"')
                 lines.append('                  io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('                  io_type="{}"'.format(ocn_pio_typename))
@@ -612,7 +610,6 @@ def buildnml(case, caseroot, compname):
             lines.append('                  type="input;output"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-#                lines.append('                  io_type="pnetcdf,cdf5"')
                 lines.append('                  io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('                  io_type="{}"'.format(ocn_pio_typename))
@@ -633,7 +630,6 @@ def buildnml(case, caseroot, compname):
             lines.append('        type="output"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-#                lines.append('        io_type="pnetcdf,cdf5"')
                 lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -946,7 +942,6 @@ def buildnml(case, caseroot, compname):
             lines.append('        precision="single"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-#                lines.append('        io_type="pnetcdf,cdf5"')
                 lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -1332,7 +1327,6 @@ def buildnml(case, caseroot, compname):
             lines.append('        precision="single"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-#                lines.append('        io_type="pnetcdf,cdf5"')
                 lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -1570,7 +1564,6 @@ def buildnml(case, caseroot, compname):
             lines.append('        precision="single"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-#                lines.append('        io_type="pnetcdf,cdf5"')
                 lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -1637,7 +1630,6 @@ def buildnml(case, caseroot, compname):
             lines.append('        precision="single"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-#                lines.append('        io_type="pnetcdf,cdf5"')
                 lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -1745,7 +1737,6 @@ def buildnml(case, caseroot, compname):
             lines.append('        type="input;output"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-#                lines.append('        io_type="pnetcdf,cdf5"')
                 lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -1763,7 +1754,6 @@ def buildnml(case, caseroot, compname):
             lines.append('        type="input;output"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-#                lines.append('        io_type="pnetcdf,cdf5"')
                 lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -1781,7 +1771,6 @@ def buildnml(case, caseroot, compname):
             lines.append('        type="input;output"')
             if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS") \
                     or ocn_grid.startswith("RRSwISC6") or ocn_grid.startswith("ARRMwISC"):
-#                lines.append('        io_type="pnetcdf,cdf5"')
                 lines.append('        io_type="{},cdf5"'.format(ocn_pio_typename))
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))

--- a/components/mpas-ocean/cime_config/config_pes.xml
+++ b/components/mpas-ocean/cime_config/config_pes.xml
@@ -617,7 +617,7 @@
     </mach>
   </grid>
   <grid name="a%T62.+oi%ARRMwISC3to18|a%TL319.+oi%ARRMwISC3to18">
-    <mach name="carpenter|blueback">
+    <mach name="carpenter|blueback|barfoot">
       <pes compset=".*MPASCICE.+MPASO.+|.*MPASSI.+MPASO.+" pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -654,7 +654,7 @@
     </mach>
   </grid>
   <grid name="a%T62.+oi%ARRMwISC3to18|a%TL319.+oi%ARRMwISC3to18">
-    <mach name="carpenter|blueback">
+    <mach name="carpenter|blueback|barfoot">
       <pes compset=".*MPASCICE.+MPASO.+|.*MPASSI.+MPASO.+" pesize="M1">
         <comment>none</comment>
         <ntasks>
@@ -728,7 +728,7 @@
     </mach>
   </grid>
   <grid name="a%T62.+oi%ARRMwISC2p4to18|a%TL319.+oi%ARRMwISC2p4to18">
-    <mach name="carpenter|blueback">
+    <mach name="carpenter|blueback|barfoot">
       <pes compset=".*MPASCICE.+MPASO.+|.*MPASSI.+MPASO.+" pesize="S1">
         <comment>none</comment>
         <ntasks>
@@ -765,7 +765,7 @@
     </mach>
   </grid>
   <grid name="a%T62.+oi%ARRMwISC2p4to18|a%TL319.+oi%ARRMwISC2p4to18">
-    <mach name="carpenter|blueback">
+    <mach name="carpenter|blueback|barfoot">
       <pes compset=".*MPASCICE.+MPASO.+|.*MPASSI.+MPASO.+" pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -802,7 +802,7 @@
     </mach>
   </grid>
   <grid name="a%T62.+oi%ARRMwISC2p4to18|a%TL319.+oi%ARRMwISC2p4to18">
-    <mach name="carpenter|blueback">
+    <mach name="carpenter|blueback|barfoot">
       <pes compset=".*MPASCICE.+MPASO.+|.*MPASSI.+MPASO.+" pesize="L1">
         <comment>none</comment>
         <ntasks>
@@ -839,7 +839,7 @@
     </mach>
   </grid>
   <grid name="a%T62.+oi%ARRMwISC2p4to18|a%TL319.+oi%ARRMwISC2p4to18">
-    <mach name="carpenter|blueback">
+    <mach name="carpenter|blueback|barfoot">
       <pes compset=".*MPASCICE.+MPASO.+|.*MPASSI.+MPASO.+" pesize="X1">
         <comment>none</comment>
         <ntasks>

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -531,6 +531,8 @@ contains
        mesh_iotype = MPAS_IO_PNETCDF5
     else if (trim(iotype) == 'netcdf') then
        mesh_iotype = MPAS_IO_NETCDF
+    else if (trim(iotype) == 'netcdf,cdf5') then
+       mesh_iotype = MPAS_IO_NETCDF5
     else if (trim(iotype) == 'netcdf4') then
        mesh_iotype = MPAS_IO_NETCDF4
     else

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -495,7 +495,8 @@ def buildnml(case, caseroot, compname):
             lines.append('                  type="none"')
             if ice_grid.startswith("oRRS1") or ice_grid.startswith("FRIS") \
                     or ice_grid.startswith("RRSwISC6") or ice_grid.startswith("ARRMwISC"):
-                lines.append('                  io_type="pnetcdf,cdf5"')
+#                lines.append('                  io_type="pnetcdf,cdf5"')
+                lines.append('                  io_type="{},cdf5"'.format(ice_pio_typename))
             else:
                 lines.append('                  io_type="{}"'.format(ice_pio_typename))
 
@@ -505,7 +506,8 @@ def buildnml(case, caseroot, compname):
             lines.append('                  type="input"')
             if ice_grid.startswith("oRRS1") or ice_grid.startswith("FRIS") \
                     or ice_grid.startswith("RRSwISC6") or ice_grid.startswith("ARRMwISC"):
-                lines.append('                  io_type="pnetcdf,cdf5"')
+#                lines.append('                  io_type="pnetcdf,cdf5"')
+                lines.append('                  io_type="{},cdf5"'.format(ice_pio_typename))
             else:
                 lines.append('                  io_type="{}"'.format(ice_pio_typename))
 
@@ -528,7 +530,8 @@ def buildnml(case, caseroot, compname):
             lines.append('                  type="input;output"')
             if ice_grid.startswith("oRRS1") or ice_grid.startswith("FRIS") \
                     or ice_grid.startswith("RRSwISC6") or ice_grid.startswith("ARRMwISC"):
-                lines.append('                  io_type="pnetcdf,cdf5"')
+#                lines.append('                  io_type="pnetcdf,cdf5"')
+                lines.append('                  io_type="{},cdf5"'.format(ice_pio_typename))
             else:
                 lines.append('                  io_type="{}"'.format(ice_pio_typename))
 
@@ -547,7 +550,8 @@ def buildnml(case, caseroot, compname):
                 lines.append('                  type="input"')
                 if ice_grid.startswith("oRRS1") or ice_grid.startswith("FRIS") \
                         or ice_grid.startswith("RRSwISC6") or ice_grid.startswith("ARRMwISC"):
-                        lines.append('                  io_type="pnetcdf,cdf5"')
+#                    lines.append('                  io_type="pnetcdf,cdf5"')
+                    lines.append('                  io_type="{},cdf5"'.format(ice_pio_typename))
                 else:
                     lines.append('                  io_type="{}"'.format(ice_pio_typename))
 

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -495,7 +495,6 @@ def buildnml(case, caseroot, compname):
             lines.append('                  type="none"')
             if ice_grid.startswith("oRRS1") or ice_grid.startswith("FRIS") \
                     or ice_grid.startswith("RRSwISC6") or ice_grid.startswith("ARRMwISC"):
-#                lines.append('                  io_type="pnetcdf,cdf5"')
                 lines.append('                  io_type="{},cdf5"'.format(ice_pio_typename))
             else:
                 lines.append('                  io_type="{}"'.format(ice_pio_typename))
@@ -506,7 +505,6 @@ def buildnml(case, caseroot, compname):
             lines.append('                  type="input"')
             if ice_grid.startswith("oRRS1") or ice_grid.startswith("FRIS") \
                     or ice_grid.startswith("RRSwISC6") or ice_grid.startswith("ARRMwISC"):
-#                lines.append('                  io_type="pnetcdf,cdf5"')
                 lines.append('                  io_type="{},cdf5"'.format(ice_pio_typename))
             else:
                 lines.append('                  io_type="{}"'.format(ice_pio_typename))
@@ -530,7 +528,6 @@ def buildnml(case, caseroot, compname):
             lines.append('                  type="input;output"')
             if ice_grid.startswith("oRRS1") or ice_grid.startswith("FRIS") \
                     or ice_grid.startswith("RRSwISC6") or ice_grid.startswith("ARRMwISC"):
-#                lines.append('                  io_type="pnetcdf,cdf5"')
                 lines.append('                  io_type="{},cdf5"'.format(ice_pio_typename))
             else:
                 lines.append('                  io_type="{}"'.format(ice_pio_typename))
@@ -550,7 +547,6 @@ def buildnml(case, caseroot, compname):
                 lines.append('                  type="input"')
                 if ice_grid.startswith("oRRS1") or ice_grid.startswith("FRIS") \
                         or ice_grid.startswith("RRSwISC6") or ice_grid.startswith("ARRMwISC"):
-#                    lines.append('                  io_type="pnetcdf,cdf5"')
                     lines.append('                  io_type="{},cdf5"'.format(ice_pio_typename))
                 else:
                     lines.append('                  io_type="{}"'.format(ice_pio_typename))

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -548,6 +548,8 @@ contains
        mesh_iotype = MPAS_IO_PNETCDF5
     else if (trim(iotype) == 'netcdf') then
        mesh_iotype = MPAS_IO_NETCDF
+    else if (trim(iotype) == 'netcdf,cdf5') then
+       mesh_iotype = MPAS_IO_NETCDF5
     else if (trim(iotype) == 'netcdf4') then
        mesh_iotype = MPAS_IO_NETCDF4
     else


### PR DESCRIPTION
Initial Barfoot port
- using intel classic
- netcdf NOT via a module
- no pnetcdf
    
Add support for "netcdf,cdf5" as an mpas stream io_type option.
- This is netcdf + 64bit_data (large file + large variable).
- This is needed to run the aerosi configurations without pnetcdf.
- Update the mpaso and mpassi stream io_type to automatically set "pnetcdf,cdf5" or "netcdf,cdf5" depending on the default pio iotype.

Tested on Carpenter, Blueback, and Barfoot.  The stream io_type is set correctly for each machine (pnetcdf vs netcdf) and for aerosi (cdf5) and non-aerosi configurations.
